### PR TITLE
Fix Kotlin plugin's warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
This removes the warning `Kotlin plugin should be enabled before 'kotlin-android-extensions'`.
