### PR TITLE
Feature - optional number row

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardId.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardId.java
@@ -79,6 +79,7 @@ public final class KeyboardId {
     public final EditorInfo mEditorInfo;
     public final boolean mClobberSettingsKey;
     public final boolean mLanguageSwitchKeyEnabled;
+    public final boolean mNumberRowKeyEnabled;
     public final String mCustomActionLabel;
     public final boolean mHasShortcutKey;
     public final boolean mIsSplitLayout;
@@ -94,6 +95,7 @@ public final class KeyboardId {
         mEditorInfo = params.mEditorInfo;
         mClobberSettingsKey = params.mNoSettingsKey;
         mLanguageSwitchKeyEnabled = params.mLanguageSwitchKeyEnabled;
+        mNumberRowKeyEnabled = params.mNumberRowKeyEnabled;
         mCustomActionLabel = (mEditorInfo.actionLabel != null)
                 ? mEditorInfo.actionLabel.toString() : null;
         mHasShortcutKey = params.mVoiceInputKeyEnabled;
@@ -112,6 +114,7 @@ public final class KeyboardId {
                 id.mClobberSettingsKey,
                 id.mHasShortcutKey,
                 id.mLanguageSwitchKeyEnabled,
+                id.mNumberRowKeyEnabled,
                 id.isMultiLine(),
                 id.imeAction(),
                 id.mCustomActionLabel,
@@ -133,6 +136,7 @@ public final class KeyboardId {
                 && other.mClobberSettingsKey == mClobberSettingsKey
                 && other.mHasShortcutKey == mHasShortcutKey
                 && other.mLanguageSwitchKeyEnabled == mLanguageSwitchKeyEnabled
+                && other.mNumberRowKeyEnabled == mNumberRowKeyEnabled
                 && other.isMultiLine() == isMultiLine()
                 && other.imeAction() == imeAction()
                 && TextUtils.equals(other.mCustomActionLabel, mCustomActionLabel)
@@ -203,6 +207,7 @@ public final class KeyboardId {
                 (passwordInput() ? " passwordInput" : ""),
                 (mHasShortcutKey ? " hasShortcutKey" : ""),
                 (mLanguageSwitchKeyEnabled ? " languageSwitchKeyEnabled" : ""),
+                (mNumberRowKeyEnabled ? " numberRowKeyEnabled" : ""),
                 (isMultiLine() ? " isMultiLine" : ""),
                 (mIsSplitLayout ? " isSplitLayout" : "")
         );

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardLayoutSet.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardLayoutSet.java
@@ -120,6 +120,7 @@ public final class KeyboardLayoutSet {
         boolean mVoiceInputKeyEnabled;
         boolean mNoSettingsKey;
         boolean mLanguageSwitchKeyEnabled;
+        boolean mNumberRowKeyEnabled;
         RichInputMethodSubtype mSubtype;
         boolean mIsSpellChecker;
         int mKeyboardWidth;
@@ -326,6 +327,11 @@ public final class KeyboardLayoutSet {
 
         public Builder setLanguageSwitchKeyEnabled(final boolean enabled) {
             mParams.mLanguageSwitchKeyEnabled = enabled;
+            return this;
+        }
+
+        public Builder setNumRowKeyEnabled(final boolean enabled) {
+            mParams.mNumberRowKeyEnabled = enabled;
             return this;
         }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -116,6 +116,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         builder.setSubtype(mRichImm.getCurrentSubtype());
         builder.setVoiceInputKeyEnabled(settingsValues.mShowsVoiceInputKey);
         builder.setLanguageSwitchKeyEnabled(mLatinIME.shouldShowLanguageSwitchKey());
+        builder.setNumRowKeyEnabled(mLatinIME.shouldShowNumberRowKey());
         builder.setSplitLayoutEnabledByUser(ProductionFlags.IS_SPLIT_KEYBOARD_SUPPORTED
                 && settingsValues.mIsSplitKeyboardEnabled);
         mKeyboardLayoutSet = builder.build();

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardBuilder.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardBuilder.java
@@ -665,6 +665,9 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
             final boolean languageSwitchKeyEnabledMatched = matchBoolean(caseAttr,
                     R.styleable.Keyboard_Case_languageSwitchKeyEnabled,
                     id.mLanguageSwitchKeyEnabled);
+            final boolean numberRowKeyEnabled = matchBoolean(caseAttr,
+                    R.styleable.Keyboard_Case_numberRowKeyEnabled,
+                    id.mNumberRowKeyEnabled);
             final boolean isMultiLineMatched = matchBoolean(caseAttr,
                     R.styleable.Keyboard_Case_isMultiLine, id.isMultiLine());
             final boolean imeActionMatched = matchInteger(caseAttr,
@@ -683,7 +686,7 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
                     && hasShortcutKeyMatched  && languageSwitchKeyEnabledMatched
                     && isMultiLineMatched && imeActionMatched && isIconDefinedMatched
                     && localeCodeMatched && languageCodeMatched && countryCodeMatched
-                    && splitLayoutMatched;
+                    && splitLayoutMatched && numberRowKeyEnabled;
 
             if (DEBUG) {
                 startTag("<%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s>%s", TAG_CASE,
@@ -709,6 +712,8 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
                                 "hasShortcutKey"),
                         booleanAttr(caseAttr, R.styleable.Keyboard_Case_languageSwitchKeyEnabled,
                                 "languageSwitchKeyEnabled"),
+                        booleanAttr(caseAttr, R.styleable.Keyboard_Case_numberRowKeyEnabled,
+                                "numberRowKeyEnabled"),
                         booleanAttr(caseAttr, R.styleable.Keyboard_Case_isMultiLine,
                                 "isMultiLine"),
                         booleanAttr(caseAttr, R.styleable.Keyboard_Case_isSplitLayout,

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -1958,6 +1958,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         return mRichImm.shouldOfferSwitchingToNextInputMethod(token, fallbackValue);
     }
 
+    public boolean shouldShowNumberRowKey() {
+        return mSettings.getCurrent().mShowsNumberRowKey;
+    }
+
     public boolean shouldShowLanguageSwitchKey() {
         // TODO: Revisit here to reorganize the settings. Probably we can/should use different
         // strategy once the implementation of

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -76,6 +76,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     public static final String PREF_SHOW_LANGUAGE_SWITCH_KEY =
             "pref_show_language_switch_key";
+    public static final String PREF_SHOW_NUMBER_ROW_KEY =
+            "pref_show_number_row_key";
     public static final String PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST =
             "pref_include_other_imes_in_language_switch_list";
     public static final String PREF_CUSTOM_INPUT_STYLES = "custom_input_styles";

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -70,6 +70,7 @@ public class SettingsValues {
     public final boolean mShowsVoiceInputKey;
     public final boolean mIncludesOtherImesInLanguageSwitchList;
     public final boolean mShowsLanguageSwitchKey;
+    public final boolean mShowsNumberRowKey;
     public final boolean mUseContactsDict;
     public final boolean mUsePersonalizedDicts;
     public final boolean mUseDoubleSpacePeriod;
@@ -144,6 +145,7 @@ public class SettingsValues {
         mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res) && mInputAttributes.mShouldShowVoiceInputKey;
         mIncludesOtherImesInLanguageSwitchList = !Settings.ENABLE_SHOW_LANGUAGE_SWITCH_KEY_SETTINGS || prefs.getBoolean(Settings.PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST, false) /* forcibly */;
         mShowsLanguageSwitchKey = prefs.getBoolean(Settings.PREF_SHOW_LANGUAGE_SWITCH_KEY, false);
+        mShowsNumberRowKey = prefs.getBoolean(Settings.PREF_SHOW_NUMBER_ROW_KEY, false);
         mUseContactsDict = prefs.getBoolean(Settings.PREF_KEY_USE_CONTACTS_DICT, true);
         mUsePersonalizedDicts = prefs.getBoolean(Settings.PREF_KEY_USE_PERSONALIZED_DICTS, true);
         mUseDoubleSpacePeriod = prefs.getBoolean(Settings.PREF_KEY_USE_DOUBLE_SPACE_PERIOD, true)

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -500,6 +500,7 @@
         <attr name="passwordInput" format="boolean" />
         <attr name="clobberSettingsKey" format="boolean" />
         <attr name="hasShortcutKey" format="boolean" />
+        <attr name="numberRowKeyEnabled" format="boolean"/>
         <attr name="languageSwitchKeyEnabled" format="boolean" />
         <attr name="isMultiLine" format="boolean" />
         <attr name="imeAction" format="enum">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,11 @@
     <!-- Option summary for showing language switch key [CHAR LIMIT=65] -->
     <string name="show_language_switch_key_summary">Show when multiple input languages are enabled</string>
 
+    <!-- Option to show number row on top of QWERTY, QWERTZ and AZERTY [CHAR LIMIT=30] -->
+    <string name="show_number_row">Number row</string>
+    <!-- Option summary for number row [CHAR LIMIT=60] -->
+    <string name="number_row_summary">Always show number row in QWERTY, QWERTZ, AZERTY layouts</string>
+
     <!-- Option for the dismiss delay of the key popup [CHAR LIMIT=25] -->
     <string name="key_preview_popup_dismiss_delay">Key popup dismiss delay</string>
     <!-- Description for delay for dismissing a popup on keypress: no delay [CHAR LIMIT=15] -->

--- a/app/src/main/res/xml/prefs_screen_appearance.xml
+++ b/app/src/main/res/xml/prefs_screen_appearance.xml
@@ -38,6 +38,12 @@
         android:defaultValue="false"
         android:persistent="true" />
     <CheckBoxPreference
+        android:key="pref_show_number_row_key"
+        android:title="@string/show_number_row"
+        android:defaultValue="false"
+        android:persistent="true"
+        android:summary="@string/number_row_summary"/>
+    <CheckBoxPreference
         android:key="pref_resize_keyboard"
         android:title="@string/prefs_resize_keyboard"
         android:defaultValue="false"

--- a/app/src/main/res/xml/rowkeys_azerty1_alt.xml
+++ b/app/src/main/res/xml/rowkeys_azerty1_alt.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="a"
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_"
+        latin:moreKeys="!text/morekeys_a" />
+    <Key
+        latin:keySpec="z"
+        latin:keyHintLabel="^"
+        latin:additionalMoreKeys="^"
+        latin:moreKeys="!text/morekeys_z" />
+    <Key
+        latin:keySpec="e"
+        latin:keyHintLabel="~"
+        latin:additionalMoreKeys="~"
+        latin:moreKeys="!text/morekeys_e" />
+    <Key
+        latin:keySpec="r"
+        latin:keyHintLabel="|"
+        latin:additionalMoreKeys="|"
+        latin:moreKeys="!text/morekeys_r" />
+    <Key
+        latin:keySpec="t"
+        latin:keyHintLabel="["
+        latin:additionalMoreKeys="["
+        latin:moreKeys="!text/morekeys_t" />
+    <Key
+        latin:keySpec="y"
+        latin:keyHintLabel="]"
+        latin:additionalMoreKeys="]"
+        latin:moreKeys="!text/morekeys_y" />
+    <Key
+        latin:keySpec="u"
+        latin:keyHintLabel="&lt;"
+        latin:additionalMoreKeys="&lt;"
+        latin:moreKeys="!text/morekeys_u" />
+    <Key
+        latin:keySpec="i"
+        latin:keyHintLabel="&gt;"
+        latin:additionalMoreKeys="&gt;"
+        latin:moreKeys="!text/morekeys_i" />
+    <Key
+        latin:keySpec="o"
+        latin:keyHintLabel="{"
+        latin:additionalMoreKeys="{"
+        latin:moreKeys="!text/morekeys_o" />
+    <Key
+        latin:keySpec="p"
+        latin:keyHintLabel="}"
+        latin:additionalMoreKeys="}" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_number.xml
+++ b/app/src/main/res/xml/rowkeys_number.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <!-- 1,2,3,4,5 -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_number_left5" />
+    <!-- 6,7,8,9,0 -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_number_right5" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_number_left5.xml
+++ b/app/src/main/res/xml/rowkeys_number_left5.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="1" />
+    <Key
+        latin:keySpec="2" />
+    <Key
+        latin:keySpec="3" />
+    <Key
+        latin:keySpec="4" />
+    <Key
+        latin:keySpec="5" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_number_right5.xml
+++ b/app/src/main/res/xml/rowkeys_number_right5.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="6" />
+    <Key
+        latin:keySpec="7" />
+    <Key
+        latin:keySpec="8" />
+    <Key
+        latin:keySpec="9" />
+    <Key
+        latin:keySpec="0" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_qwerty1_alt.xml
+++ b/app/src/main/res/xml/rowkeys_qwerty1_alt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <!-- q,w,e,r,t -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwerty1_left5_alt" />
+    <!-- y,u,i,o,p -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwerty1_right5_alt" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_qwerty1_left5_alt.xml
+++ b/app/src/main/res/xml/rowkeys_qwerty1_left5_alt.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="!text/keyspec_q"
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_"
+        latin:moreKeys="!text/morekeys_q" />
+    <Key
+        latin:keySpec="!text/keyspec_w"
+        latin:keyHintLabel="^"
+        latin:additionalMoreKeys="^"
+        latin:moreKeys="!text/morekeys_w" />
+    <Key
+        latin:keySpec="e"
+        latin:keyHintLabel="~"
+        latin:additionalMoreKeys="~"
+        latin:moreKeys="!text/morekeys_e" />
+    <Key
+        latin:keySpec="r"
+        latin:keyHintLabel="|"
+        latin:additionalMoreKeys="|"
+        latin:moreKeys="!text/morekeys_r" />
+    <Key
+        latin:keySpec="t"
+        latin:keyHintLabel="["
+        latin:additionalMoreKeys="["
+        latin:moreKeys="!text/morekeys_t" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_qwerty1_right5_alt.xml
+++ b/app/src/main/res/xml/rowkeys_qwerty1_right5_alt.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="!text/keyspec_y"
+        latin:keyHintLabel="]"
+        latin:additionalMoreKeys="]"
+        latin:moreKeys="!text/morekeys_y" />
+    <Key
+        latin:keySpec="u"
+        latin:keyHintLabel="&lt;"
+        latin:additionalMoreKeys="&lt;"
+        latin:moreKeys="!text/morekeys_u" />
+    <Key
+        latin:keySpec="i"
+        latin:keyHintLabel="&gt;"
+        latin:additionalMoreKeys="&gt;"
+        latin:moreKeys="!text/morekeys_i" />
+    <Key
+        latin:keySpec="o"
+        latin:keyHintLabel="{"
+        latin:additionalMoreKeys="{"
+        latin:moreKeys="!text/morekeys_o" />
+    <Key
+        latin:keySpec="p"
+        latin:keyHintLabel="}"
+        latin:additionalMoreKeys="}" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_qwertz1_alt.xml
+++ b/app/src/main/res/xml/rowkeys_qwertz1_alt.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    >
+    <Key
+        latin:keySpec="q"
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_" />
+    <Key
+        latin:keySpec="w"
+        latin:keyHintLabel="^"
+        latin:additionalMoreKeys="^"
+        latin:moreKeys="!text/morekeys_w" />
+    <Key
+        latin:keySpec="e"
+        latin:keyHintLabel="~"
+        latin:additionalMoreKeys="~"
+        latin:moreKeys="!text/morekeys_e" />
+    <Key
+        latin:keySpec="r"
+        latin:keyHintLabel="|"
+        latin:additionalMoreKeys="|"
+        latin:moreKeys="!text/morekeys_r" />
+    <Key
+        latin:keySpec="t"
+        latin:keyHintLabel="["
+        latin:additionalMoreKeys="["
+        latin:moreKeys="!text/morekeys_t" />
+    <Key
+        latin:keySpec="z"
+        latin:keyHintLabel="]"
+        latin:additionalMoreKeys="]"
+        latin:moreKeys="!text/morekeys_z" />
+    <Key
+        latin:keySpec="u"
+        latin:keyHintLabel="&lt;"
+        latin:additionalMoreKeys="&lt;"
+        latin:moreKeys="!text/morekeys_u" />
+    <Key
+        latin:keySpec="i"
+        latin:keyHintLabel="&gt;"
+        latin:additionalMoreKeys="&gt;"
+        latin:moreKeys="!text/morekeys_i" />
+    <Key
+        latin:keySpec="o"
+        latin:keyHintLabel="{"
+        latin:additionalMoreKeys="{"
+        latin:moreKeys="!text/morekeys_o" />
+    <Key
+        latin:keySpec="p"
+        latin:keyHintLabel="}"
+        latin:additionalMoreKeys="}" />
+</merge>

--- a/app/src/main/res/xml/rows_azerty.xml
+++ b/app/src/main/res/xml/rows_azerty.xml
@@ -23,12 +23,32 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <Row
-        latin:keyWidth="10%p"
-    >
-        <include
-            latin:keyboardLayout="@xml/rowkeys_azerty1" />
-    </Row>
+    <switch>
+        <case latin:numberRowKeyEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_number" />
+            </Row>
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_azerty1_alt" />
+            </Row>
+        </case>
+        <case latin:numberRowKeyEnabled="false"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_azerty1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_qwerty.xml
+++ b/app/src/main/res/xml/rows_qwerty.xml
@@ -23,12 +23,32 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <Row
-        latin:keyWidth="10%p"
-    >
-        <include
-            latin:keyboardLayout="@xml/rowkeys_qwerty1" />
-    </Row>
+    <switch>
+        <case latin:numberRowKeyEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_number" />
+            </Row>
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_qwerty1_alt" />
+            </Row>
+        </case>
+        <case latin:numberRowKeyEnabled="false"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_qwerty1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_qwertz.xml
+++ b/app/src/main/res/xml/rows_qwertz.xml
@@ -23,12 +23,32 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <Row
-        latin:keyWidth="10%p"
-    >
-        <include
-            latin:keyboardLayout="@xml/rowkeys_qwertz1" />
-    </Row>
+    <switch>
+        <case latin:numberRowKeyEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_number" />
+            </Row>
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_qwertz1_alt" />
+            </Row>
+        </case>
+        <case latin:numberRowKeyEnabled="false"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_qwertz1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="10%p"
     >


### PR DESCRIPTION
**Note:** This is not a complete PR. I just raised pull request to get some ideas on how to properly implement this feature as i want to contribute to my new fav keyboard.

Anyway, I made some progress on implementing the number row on QWERTY, QWERTZ and AZERTY keyboard. This is a naive approach as i still completely understand the code base. So, We can see the number row and it seems to be working fine for most part.

However, I am facing one major issue. When trying to switch to symbol keyboard from alphabet keyboard, it switches to symbol keyboard but quickly switches back to alphabet keyboard. I have traced the issue back to difference in height between the alphabet keyboard and symbol keyboard somehow causes it to click keys on following order. 
**Symbol key -> Shift key -> Symbol key** in milliseconds.

If i add some dummy keys to the symbol keyboard to match the height of the number row keyboard, then it works fine.

@dslul Could you please take a look at this and provide some suggestion on how to go about this issue and general code suggestions on how to improve?