### PR TITLE
Ensure capitalization is restored when current text is deleted (Fix #56)

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -1376,6 +1376,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     public void onUpWithDeletePointerActive() {
         if (mInputLogic.mConnection.hasSelection()) {
             mInputLogic.sendDownUpKeyEvent(KeyEvent.KEYCODE_DEL);
+            mInputLogic.sendDownUpKeyEvent(KeyEvent.KEYCODE_SHIFT_LEFT);
             cleanupInternalStateForFinishInput();
         }
     }


### PR DESCRIPTION
See #56 for a description of the issue, which this PR addresses.

When `DEL` is hit, and there is a selection active, `SHIFT_LEFT` is also triggered, so that capitalization is restored for the next input. 

I tested it, and it works as intended. However, I am confused as to why this works so fine :D Given the code, I expected the capitalization to be restored even if a smaller selection is deleted, rather than the whole text. For example, if the current text is `Supercalifragi`, I expected deleting `fragi` to restore capitalization as well. This doesn't happen, and I don't know why. Also, it seems like it gives the correct behaviour with punctuation as well. For ex, if I write `Pippo went to the cafe. He took a sweet` and then delete `He took a sweet` in one sweep selection, it restores capitalization as well. This again I am not sure as to why it happens, but I have verified it is a byproduct of this PR.