### PR TITLE
Auto day/night themes support

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -17,6 +17,7 @@
 package org.dslul.openboard.inputmethod.keyboard;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.util.Log;
 import android.view.ContextThemeWrapper;
@@ -64,6 +65,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     private KeyboardTheme mKeyboardTheme;
     private Context mThemeContext;
+    private int mCurrentUiMode;
 
     private static final KeyboardSwitcher sInstance = new KeyboardSwitcher();
 
@@ -96,9 +98,12 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     private boolean updateKeyboardThemeAndContextThemeWrapper(final Context context,
             final KeyboardTheme keyboardTheme) {
-        if (mThemeContext == null || !keyboardTheme.equals(mKeyboardTheme)) {
+        final boolean nightModeChanged = (mCurrentUiMode & Configuration.UI_MODE_NIGHT_MASK)
+                != (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK);
+        if (mThemeContext == null || !keyboardTheme.equals(mKeyboardTheme) || nightModeChanged) {
             mKeyboardTheme = keyboardTheme;
             mThemeContext = new ContextThemeWrapper(context, keyboardTheme.mStyleId);
+            mCurrentUiMode = context.getResources().getConfiguration().uiMode;
             KeyboardLayoutSet.onKeyboardThemeChanged();
             return true;
         }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -40,9 +40,12 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
     public static final int THEME_ID_KLP = 2;
     public static final int THEME_ID_LXX_LIGHT = 3;
     public static final int THEME_ID_LXX_DARK_AMOLED = 4;
+    public static final int THEME_ID_LXX_AUTO_AMOLED = 10;
     public static final int THEME_ID_LIGHT_BORDER = 5;
     public static final int THEME_ID_DARK_BORDER = 6;
     public static final int THEME_ID_LXX_DARK = 7;
+    public static final int THEME_ID_LXX_AUTO = 9;
+    public static final int THEME_ID_AUTO_BORDER = 8;
     public static final int DEFAULT_THEME_ID = THEME_ID_DARK_BORDER;
 
     private static KeyboardTheme[] AVAILABLE_KEYBOARD_THEMES;
@@ -68,6 +71,15 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
                 // This has never been selected as default theme.
                 Build.VERSION_CODES.BASE),
         new KeyboardTheme(THEME_ID_DARK_BORDER, "LXXDarkBorder", R.style.KeyboardTheme_LXX_Dark_Border,
+                // This has never been selected as default theme.
+                VERSION_CODES.LOLLIPOP),
+        new KeyboardTheme(THEME_ID_AUTO_BORDER, "LXXAutoBorder", R.style.KeyboardTheme_LXX_Auto_Border,
+                // This has never been selected as default theme.
+                VERSION_CODES.LOLLIPOP),
+        new KeyboardTheme(THEME_ID_LXX_AUTO, "LXXAuto", R.style.KeyboardTheme_LXX_Auto,
+                // This has never been selected as default theme.
+                VERSION_CODES.LOLLIPOP),
+        new KeyboardTheme(THEME_ID_LXX_AUTO_AMOLED, "LXXAutoAmoled", R.style.KeyboardTheme_LXX_Auto_Amoled,
                 // This has never been selected as default theme.
                 VERSION_CODES.LOLLIPOP),
     };

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -775,6 +775,8 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
                 cleanupInternalStateForFinishInput();
             }
         }
+        // KeyboardSwitcher will check by itself if theme update is necessary
+        mKeyboardSwitcher.updateKeyboardTheme();
         super.onConfigurationChanged(conf);
     }
 

--- a/app/src/main/res/values-night/themes-lxx-auto-amoled.xml
+++ b/app/src/main/res/values-night/themes-lxx-auto-amoled.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto_Amoled"
+           parent="KeyboardTheme.LXX_Dark_Amoled"
+            >
+    </style>
+    <style
+        name="Keyboard.LXX_Auto_Amoled"
+        parent="Keyboard"
+    >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAutoAmoled</item>
+    </style>
+    <style
+        name="KeyboardView.LXX_Auto_Amoled"
+        parent="KeyboardView.LXX_Dark_Amoled"
+    >
+    </style>
+    <style
+        name="MainKeyboardView.LXX_Auto_Amoled"
+        parent="MainKeyboardView.LXX_Dark_Amoled"
+        >
+    </style>
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+        name="EmojiPalettesView.LXX_Auto_Amoled"
+        parent="EmojiPalettesView.LXX_Dark_Amoled"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboard.LXX_Auto_Amoled"
+        parent="MoreKeysKeyboard.LXX_Dark_Amoled"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Amoled"
+        parent="MoreKeysKeyboardView.LXX_Dark_Amoled"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Amoled.Action"
+        parent="MoreKeysKeyboardView.LXX_Dark_Amoled.Action"
+        >
+    </style>
+    <style
+        name="SuggestionStripView.LXX_Auto_Amoled"
+        parent="SuggestionStripView.LXX_Dark_Amoled"
+        >
+    </style>
+    <style
+        name="SuggestionWord.LXX_Auto_Amoled"
+        parent="SuggestionWord.LXX_Dark_Amoled"
+        >
+    </style>
+</resources>

--- a/app/src/main/res/values-night/themes-lxx-auto-border.xml
+++ b/app/src/main/res/values-night/themes-lxx-auto-border.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto_Border"
+           parent="KeyboardTheme.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="Keyboard.LXX_Auto_Border"
+            parent="Keyboard"
+            >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAutoBorder</item>
+    </style>
+    <style
+            name="KeyboardView.LXX_Auto_Border"
+            parent="KeyboardView.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="MainKeyboardView.LXX_Auto_Border"
+            parent="MainKeyboardView.LXX_Dark_Border"
+            >
+    </style>
+
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+            name="EmojiPalettesView.LXX_Auto_Border"
+            parent="EmojiPalettesView.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="MoreKeysKeyboard.LXX_Auto_Border"
+            parent="MoreKeysKeyboard.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="MoreKeysKeyboardView.LXX_Auto_Border"
+            parent="MoreKeysKeyboardView.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="MoreKeysKeyboardView.LXX_Auto_Border.Action"
+            parent="MoreKeysKeyboardView.LXX_Dark_Border.Action"
+            >
+    </style>
+    <style
+            name="SuggestionStripView.LXX_Auto_Border"
+            parent="SuggestionStripView.LXX_Dark_Border"
+            >
+    </style>
+    <style
+            name="SuggestionWord.LXX_Auto_Border"
+            parent="SuggestionWord.LXX_Dark_Border"
+            >
+    </style>
+
+
+</resources>

--- a/app/src/main/res/values-night/themes-lxx-auto.xml
+++ b/app/src/main/res/values-night/themes-lxx-auto.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto"
+           parent="KeyboardTheme.LXX_Dark"
+            >
+    </style>
+    <style
+        name="Keyboard.LXX_Auto"
+        parent="Keyboard"
+    >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAuto</item>
+    </style>
+    <style
+        name="KeyboardView.LXX_Auto"
+        parent="KeyboardView.LXX_Dark"
+    >
+    </style>
+    <style
+        name="MainKeyboardView.LXX_Auto"
+        parent="MainKeyboardView.LXX_Dark"
+    >
+    </style>
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+        name="EmojiPalettesView.LXX_Auto"
+        parent="EmojiPalettesView.LXX_Dark"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboard.LXX_Auto"
+        parent="MoreKeysKeyboard.LXX_Dark"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto"
+        parent="MoreKeysKeyboardView.LXX_Dark"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto.Action"
+        parent="MoreKeysKeyboardView.LXX_Dark.Action"
+    >
+    </style>
+    <style
+        name="SuggestionStripView.LXX_Auto"
+        parent="SuggestionStripView.LXX_Dark"
+    >
+    </style>
+    <style
+        name="SuggestionWord.LXX_Auto"
+        parent="SuggestionWord.LXX_Dark"
+    >
+    </style>
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -238,9 +238,12 @@
             <enum name="KLP" value="2" />
             <enum name="LXXLight" value="3" />
             <enum name="LXXDarkAmoled" value="4" />
+            <enum name="LXXAutoAmoled" value="10" />
             <enum name="LXXDark" value="7" />
+            <enum name="LXXAuto" value="9" />
             <enum name="LXXLightBorder" value="5" />
             <enum name="LXXDarkBorder" value="6" />
+            <enum name="LXXAutoBorder" value="8" />
         </attr>
         <!-- Touch position correction -->
         <attr name="touchPositionCorrectionData" format="reference" />

--- a/app/src/main/res/values/keyboard-themes.xml
+++ b/app/src/main/res/values/keyboard-themes.xml
@@ -20,8 +20,11 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- For keyboard color scheme option dialog. -->
     <string-array name="keyboard_theme_names" translatable="false">
+        <item>@string/keyboard_theme_auto_border</item>
         <item>@string/keyboard_theme_light_border</item>
         <item>@string/keyboard_theme_dark_border</item>
+        <item>@string/keyboard_theme_material_auto</item>
+        <item>@string/keyboard_theme_material_auto_amoled</item>
         <item>@string/keyboard_theme_material_light</item>
         <item>@string/keyboard_theme_material_dark</item>
         <item>@string/keyboard_theme_material_dark_amoled</item>
@@ -31,8 +34,11 @@
     <!-- An element must be a keyboard theme id of
          {@link org.dslul.openboard.inputmethod.keyboard.KeyboardTheme#THEME_ID_ICS} etc. -->
     <integer-array name="keyboard_theme_ids" translatable="false">
+        <item>8</item>
         <item>5</item>
         <item>6</item>
+        <item>9</item>
+        <item>10</item>
         <item>3</item>
         <item>7</item>
         <item>4</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,13 +354,21 @@ mobile devices. [CHAR LIMIT=25] -->
     <string name="keyboard_theme_holo_white" translatable="false">Holo White</string>
     <!-- The keyboard theme name, Holo Blue. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_holo_blue" translatable="false">Holo Blue</string>
+    <!-- The keyboard theme name, Material (Auto). This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
+    <string name="keyboard_theme_material_auto" translatable="false">Material Auto</string>
+    <!-- The keyboard theme name, Material (Auto) (AMOLED). This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
+    <string name="keyboard_theme_material_auto_amoled" translatable="false">Material Auto (AMOLED)</string>
     <!-- The keyboard theme name, Material Dark. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_material_dark" translatable="false">Material Dark</string>
-    <!-- The keyboard theme name, Material Dark. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
+    <!-- The keyboard theme name, Material Dark (AMOLED). This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_material_dark_amoled" translatable="false">Material Dark (AMOLED)</string>
     <!-- The keyboard theme name, Material Light. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_material_light" translatable="false">Material Light</string>
+    <!-- The keyboard theme name, Material Border (Auto). This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
+    <string name="keyboard_theme_auto_border" translatable="false">Material Auto Border</string>
+    <!-- The keyboard theme name, Material Dark Border. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_dark_border" translatable="false">Material Dark Border</string>
+    <!-- The keyboard theme name, Material Light Border. This is marked as translatable="false" because this is a proper name of system-wide UI Theme.  -->
     <string name="keyboard_theme_light_border" translatable="false">Material Light Border</string>
 
     <!-- Title of the preference settings for custom input styles (language and keyboard layout pairs) [CHAR LIMIT=35]-->

--- a/app/src/main/res/values/themes-lxx-auto-amoled.xml
+++ b/app/src/main/res/values/themes-lxx-auto-amoled.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto_Amoled"
+           parent="KeyboardTheme.LXX_Light"
+            >
+    </style>
+    <style
+        name="Keyboard.LXX_Auto_Amoled"
+        parent="Keyboard"
+    >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAuto</item>
+    </style>
+    <style
+        name="KeyboardView.LXX_Auto_Amoled"
+        parent="KeyboardView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MainKeyboardView.LXX_Auto_Amoled"
+        parent="MainKeyboardView.LXX_Light"
+    >
+    </style>
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+        name="EmojiPalettesView.LXX_Auto_Amoled"
+        parent="EmojiPalettesView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboard.LXX_Auto_Amoled"
+        parent="MoreKeysKeyboard.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Amoled"
+        parent="MoreKeysKeyboardView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Amoled.Action"
+        parent="MoreKeysKeyboardView.LXX_Light.Action"
+    >
+    </style>
+    <style
+        name="SuggestionStripView.LXX_Auto_Amoled"
+        parent="SuggestionStripView.LXX_Light"
+    >
+    </style>
+    <style
+        name="SuggestionWord.LXX_Auto_Amoled"
+        parent="SuggestionWord.LXX_Light"
+    >
+    </style>
+</resources>

--- a/app/src/main/res/values/themes-lxx-auto-border.xml
+++ b/app/src/main/res/values/themes-lxx-auto-border.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto_Border"
+           parent="KeyboardTheme.LXX_Light_Border"
+            >
+    </style>
+    <style
+        name="Keyboard.LXX_Auto_Border"
+        parent="Keyboard"
+        >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAutoBorder</item>
+    </style>
+    <style
+        name="KeyboardView.LXX_Auto_Border"
+        parent="KeyboardView.LXX_Light_Border"
+        >
+    </style>
+    <style
+        name="MainKeyboardView.LXX_Auto_Border"
+        parent="MainKeyboardView.LXX_Light_Border"
+        >
+    </style>
+
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+        name="EmojiPalettesView.LXX_Auto_Border"
+        parent="EmojiPalettesView.LXX_Light_Border"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboard.LXX_Auto_Border"
+        parent="MoreKeysKeyboard.LXX_Light_Border"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Border"
+        parent="MoreKeysKeyboardView.LXX_Light_Border"
+        >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto_Border.Action"
+        parent="MoreKeysKeyboardView.LXX_Light_Border.Action"
+        >
+    </style>
+    <style
+        name="SuggestionStripView.LXX_Auto_Border"
+        parent="SuggestionStripView.LXX_Light_Border"
+        >
+    </style>
+    <style
+        name="SuggestionWord.LXX_Auto_Border"
+        parent="SuggestionWord.LXX_Light_Border"
+        >
+    </style>
+
+
+</resources>

--- a/app/src/main/res/values/themes-lxx-auto.xml
+++ b/app/src/main/res/values/themes-lxx-auto.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="KeyboardTheme.LXX_Auto"
+           parent="KeyboardTheme.LXX_Light"
+            >
+    </style>
+    <style
+        name="Keyboard.LXX_Auto"
+        parent="Keyboard"
+    >
+        <!-- This should be aligned with KeyboardTheme.THEME_ID_* -->
+        <item name="themeId">LXXAuto</item>
+    </style>
+    <style
+        name="KeyboardView.LXX_Auto"
+        parent="KeyboardView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MainKeyboardView.LXX_Auto"
+        parent="MainKeyboardView.LXX_Light"
+    >
+    </style>
+    <!-- Though {@link org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView} doesn't extend
+         {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}, some views inside it, for instance
+         delete button, need themed {@link org.dslul.openboard.inputmethod.keyboard.KeyboardView}
+         attributes. -->
+    <style
+        name="EmojiPalettesView.LXX_Auto"
+        parent="EmojiPalettesView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboard.LXX_Auto"
+        parent="MoreKeysKeyboard.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto"
+        parent="MoreKeysKeyboardView.LXX_Light"
+    >
+    </style>
+    <style
+        name="MoreKeysKeyboardView.LXX_Auto.Action"
+        parent="MoreKeysKeyboardView.LXX_Light.Action"
+    >
+    </style>
+    <style
+        name="SuggestionStripView.LXX_Auto"
+        parent="SuggestionStripView.LXX_Light"
+    >
+    </style>
+    <style
+        name="SuggestionWord.LXX_Auto"
+        parent="SuggestionWord.LXX_Light"
+    >
+    </style>
+</resources>


### PR DESCRIPTION
Very few changes were required to implement this feature. 
IME will check if night mode has changed when its `onConfigurationChange` method is invoked, and update keyboard theme if necessary.
"XXX-auto" themes simply inherit from "XXX-light" themes by default and from "XXX-dark" when night mode is enabled.

Themes that now have a "day/night" version are:
- Material
- Material Border
- Material Border AMOLED

This fixes #178 and fixes #202.