### PR TITLE
add "ə" to Italian layout

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -2163,7 +2163,8 @@ public final class KeyboardTextsTable {
         // U+0119: "ę" LATIN SMALL LETTER E WITH OGONEK
         // U+0117: "ė" LATIN SMALL LETTER E WITH DOT ABOVE
         // U+0113: "ē" LATIN SMALL LETTER E WITH MACRON
-        /* morekeys_e */ "\u00E8,\u00E9,\u00EA,\u00EB,\u0119,\u0117,\u0113",
+        // U+0259: "ə" LATIN SMALL LETTER SCHWA
+        /* morekeys_e */ "\u00E8,\u00E9,\u00EA,\u00EB,\u0119,\u0117,\u0113,\u0259",
         // U+00F9: "ù" LATIN SMALL LETTER U WITH GRAVE
         // U+00FA: "ú" LATIN SMALL LETTER U WITH ACUTE
         // U+00FB: "û" LATIN SMALL LETTER U WITH CIRCUMFLEX


### PR DESCRIPTION
Also done [here](https://github.com/rkkr/simple-keyboard/pull/214).
A non-disruptive yet useful introduction for the communities using the schwa in [Italy](https://it.wikipedia.org/wiki/Scev%C3%A0#In_Italia) and in Italian. (several sources: [[0](https://globalvoices.org/2020/09/11/are-romance-languages-becoming-more-gender-neutral/)][[1](https://thesubmarine.it/2020/08/03/schwa-linguaggio-inclusivo-vera-gheno/)][[2](https://asteriscoedizioni.com/prodotto/il-corpo-del-testo-elementi-di-traduzione-transfemminista-queer-uscita-9-dicembre/)][[3](https://www.effequ.it/femminili-singolari/)][[4](https://www.valigiablu.it/linguaggio-inclusivo-dibattito/)][[5](https://jacobinitalia.it/linvidia-dellasterisco/)], also compare [this](https://web.archive.org/web/20201209001726/https://hastebin.com/raw/lilegapujo) as [Streisand effect](https://en.wikipedia.org/wiki/Streisand_effect))

(cw: autobio) My former Grand Prime (years old!) and Italian layout had the schwa. My new mobile has not.
As happened with other keyobards, people continuously switch between Italian and Azerbaijani layouts just to get the character. I still have the muscle memory of it even after the introduction of the schwa in other keyboards.