### PR TITLE
Add German Keyboard with Umlauts

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -1109,6 +1109,74 @@ public final class KeyboardTextsTable {
         /* morekeys_swiss_row2_11 */ "\u00E0",
     };
 
+    /* Locale de: German */
+    private static final String[] TEXTS_de_DE = {
+        // U+00E4: "ä" LATIN SMALL LETTER A WITH DIAERESIS
+        // U+00E2: "â" LATIN SMALL LETTER A WITH CIRCUMFLEX
+        // U+00E0: "à" LATIN SMALL LETTER A WITH GRAVE
+        // U+00E1: "á" LATIN SMALL LETTER A WITH ACUTE
+        // U+00E6: "æ" LATIN SMALL LETTER AE
+        // U+00E3: "ã" LATIN SMALL LETTER A WITH TILDE
+        // U+00E5: "å" LATIN SMALL LETTER A WITH RING ABOVE
+        // U+0101: "ā" LATIN SMALL LETTER A WITH MACRON
+        /* morekeys_a */ "\u00E4,\u00E2,\u00E0,\u00E1,\u00E6,\u00E3,\u00E5,\u0101",
+        // U+00F6: "ö" LATIN SMALL LETTER O WITH DIAERESIS
+        // U+00F4: "ô" LATIN SMALL LETTER O WITH CIRCUMFLEX
+        // U+00F2: "ò" LATIN SMALL LETTER O WITH GRAVE
+        // U+00F3: "ó" LATIN SMALL LETTER O WITH ACUTE
+        // U+00F5: "õ" LATIN SMALL LETTER O WITH TILDE
+        // U+0153: "œ" LATIN SMALL LIGATURE OE
+        // U+00F8: "ø" LATIN SMALL LETTER O WITH STROKE
+        // U+014D: "ō" LATIN SMALL LETTER O WITH MACRON
+        /* morekeys_o */ "\u00F6,\u00F4,\u00F2,\u00F3,\u00F5,\u0153,\u00F8,\u014D",
+        // U+00E9: "é" LATIN SMALL LETTER E WITH ACUTE
+        // U+00E8: "è" LATIN SMALL LETTER E WITH GRAVE
+        // U+00EA: "ê" LATIN SMALL LETTER E WITH CIRCUMFLEX
+        // U+00EB: "ë" LATIN SMALL LETTER E WITH DIAERESIS
+        // U+0117: "ė" LATIN SMALL LETTER E WITH DOT ABOVE
+        /* morekeys_e */ "\u00E9,\u00E8,\u00EA,\u00EB,\u0117",
+        // U+00FC: "ü" LATIN SMALL LETTER U WITH DIAERESIS
+        // U+00FB: "û" LATIN SMALL LETTER U WITH CIRCUMFLEX
+        // U+00F9: "ù" LATIN SMALL LETTER U WITH GRAVE
+        // U+00FA: "ú" LATIN SMALL LETTER U WITH ACUTE
+        // U+016B: "ū" LATIN SMALL LETTER U WITH MACRON
+        /* morekeys_u */ "\u00FC,\u00FB,\u00F9,\u00FA,\u016B",
+        /* morekeys_i */ null,
+        /* keylabel_to_alpha */ null,
+        // U+00F1: "ñ" LATIN SMALL LETTER N WITH TILDE
+        // U+0144: "ń" LATIN SMALL LETTER N WITH ACUTE
+        /* morekeys_n */ "\u00F1,\u0144",
+        /* morekeys_c */ null,
+        /* double_quotes */ "!text/double_9qm_lqm",
+        // U+00DF: "ß" LATIN SMALL LETTER SHARP S
+        // U+015B: "ś" LATIN SMALL LETTER S WITH ACUTE
+        // U+0161: "š" LATIN SMALL LETTER S WITH CARON
+        /* morekeys_s */ "\u00DF,%,\u015B,\u0161",
+        /* single_quotes */ "!text/single_9qm_lqm",
+        /* keyspec_currency ~ */
+        null, null, null, null, null, null, null,
+        /* ~ morekeys_g */
+        /* single_angle_quotes */ "!text/single_raqm_laqm",
+        /* double_angle_quotes */ "!text/double_raqm_laqm",
+        /* morekeys_r ~ */
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
+        /* ~ keyspec_tablet_period */
+        // U+00FC: "ü" LATIN SMALL LETTER U WITH DIAERESIS
+        /* keyspec_swiss_row1_11 */ "\u00FC",
+        // U+00F6: "ö" LATIN SMALL LETTER O WITH DIAERESIS
+        /* keyspec_swiss_row2_10 */ "\u00F6",
+        // U+00E4: "ä" LATIN SMALL LETTER A WITH DIAERESIS
+        /* keyspec_swiss_row2_11 */ "\u00E4",
+        // U+00E8: "è" LATIN SMALL LETTER E WITH GRAVE
+        /* morekeys_swiss_row1_11 */ "\u00E8",
+        // U+00E9: "é" LATIN SMALL LETTER E WITH ACUTE
+        /* morekeys_swiss_row2_10 */ "\u00E9",
+        // U+00E0: "à" LATIN SMALL LETTER A WITH GRAVE
+        /* morekeys_swiss_row2_11 */ "\u00E0",
+    };
+
     /* Locale el: Greek */
     private static final String[] TEXTS_el = {
         /* morekeys_a ~ */
@@ -4178,6 +4246,7 @@ public final class KeyboardTextsTable {
         "cs"     , TEXTS_cs,    /*  17/ 21 Czech */
         "da"     , TEXTS_da,    /*  19/ 55 Danish */
         "de"     , TEXTS_de,    /*  16/ 66 German */
+        "de_DE"  , TEXTS_de_DE, /*         German (Germany) */
         "el"     , TEXTS_el,    /*   1/  6 Greek */
         "en"     , TEXTS_en,    /*   8/ 10 English */
         "eo"     , TEXTS_eo,    /*  26/126 Esperanto */

--- a/app/src/main/res/xml-sw600dp-land/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_german.xml
@@ -37,15 +37,15 @@
             >
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz1_left5"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Spacer
-                    latin:keyWidth="8.5%p" />
+                    latin:keyWidth="17%p" />
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz1_right5"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
         	     latin:keySpec="!text/keyspec_swiss_row1_11"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
                     latin:keyStyle="deleteKeyStyle"
                     latin:keyWidth="fillRight" />
@@ -73,18 +73,18 @@
             >
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz2_left5"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Spacer
-                    latin:keyWidth="8.5%p" />
+                    latin:keyWidth="17%p" />
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz2_right4"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
                     latin:keySpec="!text/keyspec_swiss_row2_10"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
                     latin:keySpec="!text/keyspec_swiss_row2_11"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
                     latin:keyStyle="enterKeyStyle"
                     latin:keyWidth="fillRight" />
@@ -114,19 +114,19 @@
             >
                 <Key
                     latin:keyStyle="shiftKeyStyle"
-                    latin:keyXPos="3.5%p"
+                    latin:keyXPos="2.75%p"
                     latin:keyWidth="8.5%p" />
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz3_left4"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Spacer
-                    latin:keyWidth="8.5%p" />
+                    latin:keyWidth="17%p" />
                 <include
                     latin:keyboardLayout="@xml/rowkeys_qwertz3_right3"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <include
                     latin:keyboardLayout="@xml/keys_exclamation_question"
-                    latin:keyWidth="7.5%p" />
+                    latin:keyWidth="6.75%p" />
                 <Key
                     latin:keyStyle="shiftKeyStyle"
                     latin:keyWidth="fillRight" />

--- a/app/src/main/res/xml-sw600dp/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp/rows_german.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <Row
+        latin:keyWidth="8.182%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german1" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <Row
+        latin:keyWidth="8.182%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german2" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <Row
+        latin:keyWidth="8.182%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="10.0%p" />
+        <Spacer
+            latin:keyWidth="3.181%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german3" />
+        <include
+            latin:keyboardLayout="@xml/keys_exclamation_question" />
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyXPos="-10.0%p"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>

--- a/app/src/main/res/xml/kbd_german.xml
+++ b/app/src/main/res/xml/kbd_german.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<Keyboard
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/rows_german" />
+</Keyboard>

--- a/app/src/main/res/xml/keyboard_layout_set_german.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_german.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kbd_german"
+        latin:enableProximityCharsCorrection="true"
+        latin:allowRedundantMoreKeys="true" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/app/src/main/res/xml/keyboard_layout_set_german.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_german.xml
@@ -24,7 +24,8 @@
         latin:elementName="alphabet"
         latin:elementKeyboard="@xml/kbd_german"
         latin:enableProximityCharsCorrection="true"
-        latin:allowRedundantMoreKeys="true" />
+        latin:allowRedundantMoreKeys="true"
+        latin:supportsSplitLayout="true" />
     <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -36,6 +36,7 @@
     cs: Czech/qwertz
     da: Danish/nordic
     de: German/qwertz
+    de_DE: German (Germany)/german
     de_CH: German (Switzerland)/swiss
     el: Greek/greek
     en_AU: English (Australia)/qwerty
@@ -264,6 +265,14 @@
             android:imeSubtypeLocale="de_CH"
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=swiss,AsciiCapable,SupportTouchPositionCorrection,EmojiCapable"
+            android:isAsciiCapable="true"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher_dark"
+            android:label="@string/subtype_generic"
+            android:subtypeId="0x00"
+            android:imeSubtypeLocale="de_DE"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=german,AsciiCapable,SupportTouchPositionCorrection,EmojiCapable"
             android:isAsciiCapable="true"
     />
     <subtype android:icon="@drawable/ic_ime_switcher_dark"

--- a/app/src/main/res/xml/rowkeys_german1.xml
+++ b/app/src/main/res/xml/rowkeys_german1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz1_left5" />
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz1_right5" />
+    <Key
+        latin:keySpec="!text/keyspec_swiss_row1_11" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_german2.xml
+++ b/app/src/main/res/xml/rowkeys_german2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz2_left5" />
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz2_right4" />
+    <Key
+        latin:keySpec="!text/keyspec_swiss_row2_10"/>
+    <Key
+        latin:keySpec="!text/keyspec_swiss_row2_11"/>
+</merge>

--- a/app/src/main/res/xml/rowkeys_german3.xml
+++ b/app/src/main/res/xml/rowkeys_german3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <!-- y,x,c,v -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz3_left4" />
+    <!-- b,n,m -->
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwertz3_right3" />
+</merge>

--- a/app/src/main/res/xml/rows_german.xml
+++ b/app/src/main/res/xml/rows_german.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
+    <Row
+        latin:keyWidth="9.091%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german1" />
+    </Row>
+    <Row
+        latin:keyWidth="9.091%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german2" />
+    </Row>
+    <Row
+        latin:keyWidth="9.2%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="15%p"
+            latin:visualInsetsRight="1%p" />
+        <Spacer
+            latin:keyWidth="2.8%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_german3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyXPos="-15%p"
+            latin:keyWidth="fillRight"
+            latin:visualInsetsLeft="1%p" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>


### PR DESCRIPTION
Resolves #168 

This commit defines a new keyboard German (Germany) (country code de_DE) that includes the most important Umlauts äöü. The default alternate characters on longpress are set to the numbers, for u and o, since ü and ö have their own keys now. ß is the new default alternate char for s.
The old German (country code de) keyboard based on a QWERTZ layout without umlauts remains in place.