### PR TITLE
Added ß to German Layout

### DIFF
--- a/app/src/main/res/xml/rowkeys_german3.xml
+++ b/app/src/main/res/xml/rowkeys_german3.xml
@@ -27,4 +27,17 @@
     <!-- b,n,m -->
     <include
         latin:keyboardLayout="@xml/rowkeys_qwertz3_right3" />
+    <!-- ß -->
+    <switch>
+        <case
+            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetAutomaticShifted|symbolsShifted"
+            >
+            <Key
+                latin:keySpec="ẞ" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="ß" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rows_german.xml
+++ b/app/src/main/res/xml/rows_german.xml
@@ -54,8 +54,6 @@
             latin:keyStyle="shiftKeyStyle"
             latin:keyWidth="15%p"
             latin:visualInsetsRight="1%p" />
-        <Spacer
-            latin:keyWidth="2.8%p" />
         <include
             latin:keyboardLayout="@xml/rowkeys_german3" />
         <Key


### PR DESCRIPTION
- Added ß to German Layout
German layout was missing it. BTY i tested it, it does work fine.