### PR TITLE
Make dark characters higher contrast

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -87,7 +87,7 @@
     <color name="key_background_pressed_lxx_dark">#19FFFFFF</color>
     <color name="action_key_background_lxx_dark">#5E97F6</color>
     <color name="action_key_background_pressed_lxx_dark">#86b0f6</color>
-    <color name="suggested_word_background_selected_lxx_dark">#19FFFFFF</color>
+    <color name="suggested_word_background_selected_lxx_dark">#1CFFFFFF</color>
     <color name="gesture_floating_preview_color_lxx_dark">#E621272B</color>
     <color name="emoji_tab_page_indicator_background_lxx_dark">#21272B</color>
     <!-- Color resources for LXX_Dark_Border theme.
@@ -101,6 +101,7 @@
     <!-- Color resources for LXX_Dark_Amoled theme.
          15%:0x26 70%:0xB3 75%:0xC0 80%:0xCC 85%:0xD9 90%:0xE6 -->
     <color name="background_amoled_black">#000000</color>
+    <color name="background_amoled_dark">#1A1A1A</color>
 
     <color name="popup_background_material_dark_theme">#ff3c474c</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -72,7 +72,7 @@
 
     <!-- Color resources for LXX_Dark theme.
          10%:0x19 50%:0x80 70%:0xB3 75%:0xC0 80%:0xCC 85%:0xD9 90%:0xE6  -->
-    <color name="key_text_color_lxx_dark">#CCFFFFFF</color>
+    <color name="key_text_color_lxx_dark">#FFFFFF</color>
     <color name="key_functional_text_color_lxx_dark">#CCFFFFFF</color>
     <color name="key_text_inactive_color_lxx_dark">#80FFFFFF</color>
     <color name="key_hint_letter_color_lxx_dark">#80FFFFFF</color>

--- a/app/src/main/res/values/themes-lxx-dark-amoled.xml
+++ b/app/src/main/res/values/themes-lxx-dark-amoled.xml
@@ -77,7 +77,7 @@
         name="SuggestionStripView.LXX_Dark_Amoled"
         parent="SuggestionStripView.LXX_Dark"
     >
-        <item name="android:background">@color/background_amoled_black</item>
+        <item name="android:background">@color/background_amoled_dark</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/themes-lxx-dark.xml
+++ b/app/src/main/res/values/themes-lxx-dark.xml
@@ -51,7 +51,7 @@
         <item name="spacebarBackground">@drawable/btn_keyboard_spacebar_lxx_dark</item>
         <item name="keyTextColor">@color/key_text_color_lxx_dark</item>
         <item name="keyTextInactivatedColor">@color/key_functional_text_color_lxx_dark</item>
-        <item name="functionalTextColor">@color/key_text_color_lxx_dark</item>
+        <item name="functionalTextColor">@color/key_functional_text_color_lxx_dark</item>
         <item name="keyHintLetterColor">@color/key_hint_letter_color_lxx_dark</item>
         <item name="keyHintLabelColor">@color/key_text_inactive_color_lxx_dark</item>
         <item name="keyShiftedLetterHintInactivatedColor">@color/key_text_inactive_color_lxx_dark</item>


### PR DESCRIPTION
Tweak character styling slightly so that the characters are full-white, making them a bit easier to see. Also, switched the "functional text" names to match.