### PR TITLE
Enable direct boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,8 @@
         <!-- Services -->
         <service android:name="LatinIME"
                 android:label="@string/english_ime_name"
-                android:permission="android.permission.BIND_INPUT_METHOD">
+                android:permission="android.permission.BIND_INPUT_METHOD"
+                android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.view.InputMethod" />
             </intent-filter>

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardTheme.java
@@ -20,10 +20,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
-import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.dslul.openboard.inputmethod.latin.R;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -190,7 +190,7 @@ public final class KeyboardTheme implements Comparable<KeyboardTheme> {
     }
 
     public static KeyboardTheme getKeyboardTheme(final Context context) {
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        final SharedPreferences prefs = DeviceProtectedUtils.getSharedPreferences(context);
         final KeyboardTheme[] availableThemeArray = getAvailableThemeArray(context);
         return getKeyboardTheme(prefs, Build.VERSION.SDK_INT, availableThemeArray);
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/MainKeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/MainKeyboardView.java
@@ -27,7 +27,6 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
 import android.graphics.Typeface;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -56,6 +55,7 @@ import org.dslul.openboard.inputmethod.latin.SuggestedWords;
 import org.dslul.openboard.inputmethod.latin.common.Constants;
 import org.dslul.openboard.inputmethod.latin.common.CoordinateUtils;
 import org.dslul.openboard.inputmethod.latin.settings.DebugSettings;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.LanguageOnSpacebarUtils;
 import org.dslul.openboard.inputmethod.latin.utils.TypefaceUtils;
 
@@ -197,7 +197,7 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
 
         PointerTracker.init(mainKeyboardViewAttr, mTimerHandler, this /* DrawingProxy */);
 
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        final SharedPreferences prefs = DeviceProtectedUtils.getSharedPreferences(context);
         final boolean forceNonDistinctMultitouch = prefs.getBoolean(
                 DebugSettings.PREF_FORCE_NON_DISTINCT_MULTITOUCH, false);
         final boolean hasDistinctMultitouch = context.getPackageManager()

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -47,6 +46,7 @@ import org.dslul.openboard.inputmethod.latin.AudioAndHapticFeedbackManager;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.RichInputMethodSubtype;
 import org.dslul.openboard.inputmethod.latin.common.Constants;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 
 import androidx.viewpager2.widget.ViewPager2;
@@ -118,7 +118,7 @@ public final class EmojiPalettesView extends LinearLayout
         final KeyboardLayoutSet layoutSet = builder.build();
         final TypedArray emojiPalettesViewAttr = context.obtainStyledAttributes(attrs,
                 R.styleable.EmojiPalettesView, defStyle, R.style.EmojiPalettesView);
-        mEmojiCategory = new EmojiCategory(PreferenceManager.getDefaultSharedPreferences(context),
+        mEmojiCategory = new EmojiCategory(DeviceProtectedUtils.getSharedPreferences(context),
                 res, layoutSet, emojiPalettesViewAttr);
         mCategoryIndicatorEnabled = emojiPalettesViewAttr.getBoolean(
                 R.styleable.EmojiPalettesView_categoryIndicatorEnabled, false);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -16,8 +16,6 @@
 
 package org.dslul.openboard.inputmethod.latin;
 
-import android.Manifest.permission;
-import android.app.ActivityOptions;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -34,7 +32,6 @@ import android.os.Build;
 import android.os.Debug;
 import android.os.IBinder;
 import android.os.Message;
-import android.preference.PreferenceManager;
 import android.text.InputType;
 import android.util.Log;
 import android.util.PrintWriterPrinter;
@@ -82,6 +79,7 @@ import org.dslul.openboard.inputmethod.latin.suggestions.SuggestionStripView;
 import org.dslul.openboard.inputmethod.latin.suggestions.SuggestionStripViewAccessor;
 import org.dslul.openboard.inputmethod.latin.touchinputconsumer.GestureConsumer;
 import org.dslul.openboard.inputmethod.latin.utils.ApplicationUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.DialogUtils;
 import org.dslul.openboard.inputmethod.latin.utils.IntentUtils;
 import org.dslul.openboard.inputmethod.latin.utils.JniUtils;
@@ -586,7 +584,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     @Override
     public void onCreate() {
         Settings.init(this);
-        DebugFlags.init(PreferenceManager.getDefaultSharedPreferences(this));
+        DebugFlags.init(DeviceProtectedUtils.getSharedPreferences(this));
         RichInputMethodManager.init(this);
         mRichImm = RichInputMethodManager.getInstance();
         KeyboardSwitcher.init(this);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/RichInputMethodManager.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/RichInputMethodManager.java
@@ -22,7 +22,6 @@ import android.inputmethodservice.InputMethodService;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -33,6 +32,7 @@ import org.dslul.openboard.inputmethod.compat.InputMethodManagerCompatWrapper;
 import org.dslul.openboard.inputmethod.compat.InputMethodSubtypeCompatUtils;
 import org.dslul.openboard.inputmethod.latin.settings.Settings;
 import org.dslul.openboard.inputmethod.latin.utils.AdditionalSubtypeUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.LanguageOnSpacebarUtils;
 import org.dslul.openboard.inputmethod.latin.utils.SubtypeLocaleUtils;
 
@@ -111,7 +111,7 @@ public class RichInputMethodManager {
     }
 
     public InputMethodSubtype[] getAdditionalSubtypes() {
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        final SharedPreferences prefs = DeviceProtectedUtils.getSharedPreferences(mContext);
         final String prefAdditionalSubtypes = Settings.readPrefAdditionalSubtypes(
                 prefs, mContext.getResources());
         return AdditionalSubtypeUtils.createAdditionalSubtypesArray(prefAdditionalSubtypes);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/SystemBroadcastReceiver.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/SystemBroadcastReceiver.java
@@ -24,7 +24,6 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Process;
-import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
@@ -32,6 +31,7 @@ import android.view.inputmethod.InputMethodSubtype;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardLayoutSet;
 import org.dslul.openboard.inputmethod.latin.settings.Settings;
 import org.dslul.openboard.inputmethod.latin.setup.SetupActivity;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.UncachedInputMethodManagerUtils;
 
 /**
@@ -106,7 +106,7 @@ public final class SystemBroadcastReceiver extends BroadcastReceiver {
         if (Log.isLoggable(TAG, Log.INFO)) {
             Log.i(TAG, "toggleAppIcon() : FLAG_SYSTEM = " + isSystemApp);
         }
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        final SharedPreferences prefs = DeviceProtectedUtils.getSharedPreferences(context);
         context.getPackageManager().setComponentEnabledSetting(
                 new ComponentName(context, SetupActivity.class),
                 Settings.readShowSetupWizardIcon(prefs, context)

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
@@ -52,7 +52,7 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
         // initialization method of these classes here. See {@link LatinIME#onCreate()}.
         AudioAndHapticFeedbackManager.init(context);
 
-        final SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
+        final SharedPreferences prefs = getSharedPreferences();
 
         if (!Settings.isInternal(prefs)) {
             removePreference(Settings.SCREEN_DEBUG);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CustomInputStyleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CustomInputStyleSettingsFragment.java
@@ -95,6 +95,7 @@ public final class CustomInputStyleSettingsFragment extends PreferenceFragment
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getPreferenceManager().setStorageDeviceProtected();
 
         mPrefs = getPreferenceManager().getSharedPreferences();
         RichInputMethodManager.init(getActivity());

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -22,7 +22,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
-import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.dslul.openboard.inputmethod.latin.AudioAndHapticFeedbackManager;
@@ -30,6 +29,7 @@ import org.dslul.openboard.inputmethod.latin.InputAttributes;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.common.StringUtils;
 import org.dslul.openboard.inputmethod.latin.utils.AdditionalSubtypeUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.JniUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 import org.dslul.openboard.inputmethod.latin.utils.RunInLocale;
@@ -152,7 +152,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     private void onCreate(final Context context) {
         mContext = context;
         mRes = context.getResources();
-        mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+        mPrefs = DeviceProtectedUtils.getSharedPreferences(context);
         mPrefs.registerOnSharedPreferenceChangeListener(this);
         upgradeAutocorrectionSettings(mPrefs, mRes);
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SubScreenFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SubScreenFragment.java
@@ -100,6 +100,7 @@ public abstract class SubScreenFragment extends PreferenceFragment
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getPreferenceManager().setStorageDeviceProtected();
         mSharedPreferenceChangeListener = new OnSharedPreferenceChangeListener() {
             @Override
             public void onSharedPreferenceChanged(final SharedPreferences prefs, final String key) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidSpellCheckerService.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidSpellCheckerService.java
@@ -18,7 +18,6 @@ package org.dslul.openboard.inputmethod.latin.spellcheck;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 import android.service.textservice.SpellCheckerService;
 import android.text.InputType;
 import android.view.inputmethod.EditorInfo;
@@ -37,6 +36,7 @@ import org.dslul.openboard.inputmethod.latin.SuggestedWords;
 import org.dslul.openboard.inputmethod.latin.common.ComposedData;
 import org.dslul.openboard.inputmethod.latin.settings.SettingsValuesForSuggestion;
 import org.dslul.openboard.inputmethod.latin.utils.AdditionalSubtypeUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
 import org.dslul.openboard.inputmethod.latin.utils.SuggestionResults;
 
@@ -95,7 +95,7 @@ public final class AndroidSpellCheckerService extends SpellCheckerService
         super.onCreate();
         mRecommendedThreshold = Float.parseFloat(
                 getString(R.string.spellchecker_recommended_threshold_value));
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        final SharedPreferences prefs = DeviceProtectedUtils.getSharedPreferences(this);
         prefs.registerOnSharedPreferenceChangeListener(this);
         onSharedPreferenceChanged(prefs, PREF_USE_CONTACTS_KEY);
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/userdictionary/UserDictionaryList.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/userdictionary/UserDictionaryList.java
@@ -51,6 +51,7 @@ public class UserDictionaryList extends PreferenceFragment {
     @Override
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
+        getPreferenceManager().setStorageDeviceProtected();
         setPreferenceScreen(getPreferenceManager().createPreferenceScreen(getActivity()));
     }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
@@ -24,17 +24,17 @@ public final class DeviceProtectedUtils {
 
     private static Context deviceProtectedContext;
 
-    public static Context getContext(final Context context) {
+    public static SharedPreferences getSharedPreferences(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(getDeviceProtectedContext(context));
+    }
+
+    private static Context getDeviceProtectedContext(final Context context) {
         if (deviceProtectedContext != null) {
             return deviceProtectedContext;
         }
         deviceProtectedContext = context.isDeviceProtectedStorage()
                 ? context : context.createDeviceProtectedStorageContext();
         return deviceProtectedContext;
-    }
-
-    public static SharedPreferences getSharedPreferences(final Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(getContext(context));
     }
 
     private DeviceProtectedUtils() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dslul.openboard.inputmethod.latin.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+public final class DeviceProtectedUtils {
+
+    private static Context deviceProtectedContext;
+
+    public static Context getContext(final Context context) {
+        if (deviceProtectedContext != null) {
+            return deviceProtectedContext;
+        }
+        deviceProtectedContext = context.isDeviceProtectedStorage()
+                ? context : context.createDeviceProtectedStorageContext();
+        return deviceProtectedContext;
+    }
+
+    public static SharedPreferences getSharedPreferences(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(getContext(context));
+    }
+
+    private DeviceProtectedUtils() {
+        // This utility class is not publicly instantiable.
+    }
+}


### PR DESCRIPTION
Allow the keyboard to be usable at startup, before the user has logged in (i.e. to enter the device password). This is done by performing the following changes:
1. Adding `directBootAware` to the LatinIME service
2. Using device protected preferences throughout the application, instead of (by default) credential encrypted storage. Two groups of changes are made to use these preferences:
    1. Adding a Util class which is used for the static call `PreferenceManager.getDefaultSharedPreferences(context);`
    2. Updating classes that extend PreferenceFragment to call `getPreferenceManager().setStorageDeviceProtected();` in their `onCreate` method.