### PR TITLE
Make amoled enter key use system accent color

### DIFF
--- a/app/src/main/res/drawable/btn_keyboard_key_lxx_dark_amoled.xml
+++ b/app/src/main/res/drawable/btn_keyboard_key_lxx_dark_amoled.xml
@@ -3,9 +3,9 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Action keys. -->
     <item android:state_active="true" android:state_pressed="true"
-          android:drawable="@color/key_background_pressed_lxx_dark" />
+        android:drawable="@drawable/btn_keyboard_key_action_pressed_lxx_dark" />
     <item android:state_active="true"
-          android:drawable="@color/background_amoled_black" />
+        android:drawable="@drawable/btn_keyboard_key_action_normal_lxx_dark" />
 
     <!-- Toggle keys. Use checkable/checked state. -->
     <item android:state_checkable="true" android:state_checked="true" android:state_pressed="true"


### PR DESCRIPTION
I felt that the Amoled keyboard looked a bit better with some accent color on the enter key (since the Shift key is already colored, as well as icons in the emoji pane). 

Compatible with #395 .