### PR TITLE
Fix target and compile SDK versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion "android-S"
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "org.dslul.openboard.inputmethod.latin"
         minSdkVersion 19
-        targetSdkVersion "S"
+        targetSdkVersion 31
         versionCode 15
         versionName '1.4.3'
     }


### PR DESCRIPTION
With the latest Android 12 beta (beta 3), the compile and target SDK versions are changed from "android-S" and "S" to 31. Update build.gradle to reflect these changes.