### PR TITLE
Fix dictionary persistence with Direct Boot

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/DeviceProtectedUtils.java
@@ -18,14 +18,20 @@ package org.dslul.openboard.inputmethod.latin.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
 
 public final class DeviceProtectedUtils {
 
     static final String TAG = DeviceProtectedUtils.class.getSimpleName();
 
     public static SharedPreferences getSharedPreferences(final Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return PreferenceManager.getDefaultSharedPreferences(context);
+        }
         Context deviceProtectedContext = getDeviceProtectedContext(context);
         SharedPreferences deviceProtectedPreferences = PreferenceManager.getDefaultSharedPreferences(deviceProtectedContext);
         if (deviceProtectedPreferences.getAll().isEmpty()) {
@@ -35,6 +41,7 @@ public final class DeviceProtectedUtils {
         return deviceProtectedPreferences;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     private static Context getDeviceProtectedContext(final Context context) {
         return context.isDeviceProtectedStorage()
                 ? context : context.createDeviceProtectedStorageContext();


### PR DESCRIPTION
Trigger app restart when credential-encrypted storage is unlocked, to refresh dictionary from credential encrypted storage. This fixes an issue where learned dictionary and frequencies are reset after device restart.