### PR TITLE
Fixed the blocked texts on the third "setting up" page

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/setup/SetupWizardActivity.java
@@ -22,26 +22,21 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.provider.Settings;
 import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.VideoView;
 
-import androidx.annotation.RequiresApi;
-
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.settings.SettingsActivity;
 import org.dslul.openboard.inputmethod.latin.utils.LeakGuardHandlerWrapper;
 import org.dslul.openboard.inputmethod.latin.utils.UncachedInputMethodManagerUtils;
-import org.w3c.dom.Text;
 
 import java.util.ArrayList;
 
@@ -444,8 +439,8 @@ public final class SetupWizardActivity extends Activity implements View.OnClickL
         private Runnable mAction;
 
         public SetupStep(final int stepNo, final String applicationName, final TextView bulletView,
-                         final View stepView, final int title, final int instruction,
-                         final int finishedInstruction, final int actionIcon, final int actionLabel) {
+                final View stepView, final int title, final int instruction,
+                final int finishedInstruction, final int actionIcon, final int actionLabel) {
             mStepNo = stepNo;
             mStepView = stepView;
             mBulletView = bulletView;
@@ -462,9 +457,6 @@ public final class SetupWizardActivity extends Activity implements View.OnClickL
 
             mActionLabel = mStepView.findViewById(R.id.setup_step_action_label);
             mActionLabel.setText(res.getString(actionLabel));
-            ViewGroup.LayoutParams params = mActionLabel.getLayoutParams();
-            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
-            mActionLabel.setLayoutParams(params);
             if (actionIcon == 0) {
                 final int paddingEnd = mActionLabel.getPaddingEnd();
                 mActionLabel.setPaddingRelative(paddingEnd, 0, paddingEnd, 0);

--- a/app/src/main/res/layout/setup_step.xml
+++ b/app/src/main/res/layout/setup_step.xml
@@ -33,6 +33,7 @@
         android:paddingBottom="@dimen/setup_step_vertical_padding" />
     <TextView
         android:id="@+id/setup_step_action_label"
+        android:layout_height="wrap_content"
         style="@style/setupStepActionLabelStyle"
         android:layout_marginTop="@dimen/setup_step_horizontal_line_height" />
 </LinearLayout>


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #426, and I have fixed the blocked texts on the third "setting up" page. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/130943304-ae5b3c31-1450-4a65-ad9b-811a81c80bef.png" alt="copy" width="250"/>

Thanks again! Have a nice day! :