### PR TITLE
Added capital sharp s (ẞ) as long-press option for German layout

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -1127,9 +1127,10 @@ public final class KeyboardTextsTable {
         /* morekeys_c */ null,
         /* double_quotes */ "!text/double_9qm_lqm",
         // U+00DF: "ß" LATIN SMALL LETTER SHARP S
+        // U+1E9E: "ẞ" LATIN CAPITAL LETTER SHARP S
         // U+015B: "ś" LATIN SMALL LETTER S WITH ACUTE
         // U+0161: "š" LATIN SMALL LETTER S WITH CARON
-        /* morekeys_s */ "\u00DF,%,\u015B,\u0161",
+        /* morekeys_s */ "\u00DF,%,\u015B,\u0161,\u1E9E",
         /* single_quotes */ "!text/single_9qm_lqm",
         /* keyspec_currency ~ */
         null, null, null, null, null, null, null,


### PR DESCRIPTION
I saw the Pull Request of  mahmoudk1000 https://github.com/dslul/openboard/pull/339 , as I wanted to use the capital s, but I personally prefer the less cluttered layout, so I added the capital letter as a long press-option to the s in the German layout.