### PR TITLE
Fixed build and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can use [this tool](https://github.com/remi0s/aosp-dictionary-tools) to crea
 
 Install java:
 ```sh
-sudo pacman -S jdk8-openjdk jre8-openjdk jre8-openjdk-headless
+sudo pacman -S jdk11-openjdk jre11-openjdk jre11-openjdk-headless
 ```
 
 Install Android SDK:
@@ -39,11 +39,6 @@ sudo snap install androidsdk
 Configure your SDK location in your `~/.bash_profile` or `~/.bashrc`:
 ```bash
 export ANDROID_SDK_ROOT=~/snap/androidsdk/current/AndroidSDK/
-```
-
-Install the platform tools for your target android version:
-```sh
-androidsdk "platform-tools" "platforms;android-29"
 ```
 
 Compile the project. This will install all dependencies, make sure to accept

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.31'
     repositories {
         jcenter()
         google()


### PR DESCRIPTION
Hi,

I was trying to build this on my arch install and ran into some trouble getting it done.

When compiling to SDK 31 it will fail on JDK8. I solved this by using JDK11 as per [microsoft docs](https://docs.microsoft.com/en-us/answers/questions/452586/xamarin-android-unrecognized-attribute-name-module.html). This also failed with another issue which was solved by updating the kotlin version.

I removed lines about adding android platform since it is outdated and grade build will automatically get the platform required.

`pacman` lines about jdk have also been updated.

Thanks and have a nice day!