### PR TITLE
#455 Disabling long pressing space for keyboard change

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/PointerTracker.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/PointerTracker.java
@@ -1082,7 +1082,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             return;
         }
         final int code = key.getCode();
-        if (code == Constants.CODE_SPACE || code == Constants.CODE_LANGUAGE_SWITCH) {
+        if (code == Constants.CODE_SPACE&&Settings.getInstance().getCurrent().mSpaceForLangChange || code == Constants.CODE_LANGUAGE_SWITCH) {
             // Long pressing the space key invokes IME switcher dialog.
             if (sListener.onCustomRequest(Constants.CUSTOM_CODE_SHOW_INPUT_METHOD_PICKER)) {
                 cancelKeyTracking();

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -108,6 +108,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final String PREF_SHOW_HINTS = "pref_show_hints";
 
+    public static final String PREF_SPACE_TO_CHANGE_LANG = "prefs_long_press_keyboard_to_change_lang";
+
     // This preference key is deprecated. Use {@link #PREF_SHOW_LANGUAGE_SWITCH_KEY} instead.
     // This is being used only for the backward compatibility.
     private static final String PREF_SUPPRESS_LANGUAGE_SWITCH_KEY =

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -71,6 +71,7 @@ public class SettingsValues {
     public final boolean mIncludesOtherImesInLanguageSwitchList;
     public final boolean mShowsNumberRow;
     public final boolean mShowsHints;
+    public final boolean mSpaceForLangChange;
     public final boolean mShowsLanguageSwitchKey;
     public final boolean mShowsEmojiKey;
     public final boolean mUsePersonalizedDicts;
@@ -147,6 +148,7 @@ public class SettingsValues {
         mIncludesOtherImesInLanguageSwitchList = !Settings.ENABLE_SHOW_LANGUAGE_SWITCH_KEY_SETTINGS || prefs.getBoolean(Settings.PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST, false) /* forcibly */;
         mShowsNumberRow = prefs.getBoolean(Settings.PREF_SHOW_NUMBER_ROW, false);
         mShowsHints = prefs.getBoolean(Settings.PREF_SHOW_HINTS, true);
+        mSpaceForLangChange = prefs.getBoolean(Settings.PREF_SPACE_TO_CHANGE_LANG, true);
         mShowsLanguageSwitchKey = prefs.getBoolean(Settings.PREF_SHOW_LANGUAGE_SWITCH_KEY, false);
         mShowsEmojiKey = prefs.getBoolean(Settings.PREF_SHOW_EMOJI_KEY, false);
         mUsePersonalizedDicts = prefs.getBoolean(Settings.PREF_KEY_USE_PERSONALIZED_DICTS, true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,9 @@
     <!-- Description of the settings to show hints -->
     <string name="show_hints_summary">Show long-press hints</string>
 
+    <!-- Title of the settings to disable long press space to change language -->
+    <string name="prefs_long_press_keyboard_to_change_lang">Long press to change lang</string>
+
     <!-- Title of the settings to enable keyboard resizing -->
     <string name="prefs_resize_keyboard">Enable keyboard resizing</string>
     <!-- Title of the settings for setting keyboard height -->

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -35,6 +35,11 @@
         android:defaultValue="true"
         android:persistent="true" />
     <CheckBoxPreference
+        android:key="prefs_long_press_keyboard_to_change_lang"
+        android:title="@string/prefs_long_press_keyboard_to_change_lang"
+        android:persistent="true"
+        android:defaultValue="true" />
+    <CheckBoxPreference
         android:key="pref_show_language_switch_key"
         android:title="@string/show_language_switch_key"
         android:defaultValue="false"


### PR DESCRIPTION
Added a preference option in the preferences tab that allows the user to 
- Disable long pressing spacebar from opening the input switcher.
This resolves issue #455 