### PR TITLE
Fix rendering of icons with system accent tint

### DIFF
--- a/app/src/main/res/drawable-v31/ic_emoji_activities_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_activities_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:drawable="@drawable/ic_emoji_activities_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_activities_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_activities_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_activities_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_activities_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:drawable="@drawable/ic_emoji_activities_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_animals_nature_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_animals_nature_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_animals_nature_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_animals_nature_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_animals_nature_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_animals_nature_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_animals_nature_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_animals_nature_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_emoticons_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_emoticons_lxx_dark.xml
@@ -20,13 +20,13 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:drawable="@drawable/ic_emoji_emoticons_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_emoticons_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_emoticons_lxx_light.xml
@@ -20,13 +20,13 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_emoticons_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_emoticons_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:drawable="@drawable/ic_emoji_emoticons_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_flags_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_flags_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:drawable="@drawable/ic_emoji_flags_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_flags_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_flags_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_flags_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_flags_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:drawable="@drawable/ic_emoji_flags_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_food_drink_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_food_drink_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_food_drink_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_food_drink_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_food_drink_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_food_drink_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_food_drink_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_food_drink_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_objects_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_objects_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_objects_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_objects_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_objects_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_objects_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_objects_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_objects_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_people_body_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_people_body_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_people_body_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_people_body_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_people_body_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_people_body_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_people_body_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_people_body_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_recents_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_recents_lxx_dark.xml
@@ -19,13 +19,13 @@
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
     </item>
     <item android:drawable="@drawable/ic_emoji_recents_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_recents_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_recents_lxx_light.xml
@@ -19,13 +19,13 @@
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_pressed="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:state_selected="true">
-        <bitmap android:src="@drawable/ic_emoji_recents_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+        <bitmap android:src="@drawable/ic_emoji_recents_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
     </item>
     <item android:drawable="@drawable/ic_emoji_recents_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_smileys_emotion_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_smileys_emotion_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_smileys_emotion_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_smileys_emotion_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_smileys_emotion_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_smileys_emotion_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_symbols_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_symbols_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_symbols_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_symbols_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_symbols_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_symbols_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_symbols_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_symbols_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_travel_places_lxx_dark.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_travel_places_lxx_dark.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
   </item>
   <item android:drawable="@drawable/ic_emoji_travel_places_normal_lxx_dark" />
 </selector>

--- a/app/src/main/res/drawable-v31/ic_emoji_travel_places_lxx_light.xml
+++ b/app/src/main/res/drawable-v31/ic_emoji_travel_places_lxx_light.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_focused="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_pressed="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:state_selected="true">
-    <bitmap android:src="@drawable/ic_emoji_travel_places_normal_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    <bitmap android:src="@drawable/ic_emoji_travel_places_activated_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
   </item>
   <item android:drawable="@drawable/ic_emoji_travel_places_normal_lxx_light" />
 </selector>

--- a/app/src/main/res/drawable-v31/sym_keyboard_shift_locked_lxx_dark_system_accent.xml
+++ b/app/src/main/res/drawable-v31/sym_keyboard_shift_locked_lxx_dark_system_accent.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@drawable/sym_keyboard_shift_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />
+    android:src="@drawable/sym_keyboard_shift_locked_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_dark" />

--- a/app/src/main/res/drawable-v31/sym_keyboard_shift_locked_lxx_light_system_accent.xml
+++ b/app/src/main/res/drawable-v31/sym_keyboard_shift_locked_lxx_light_system_accent.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@drawable/sym_keyboard_shift_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />
+    android:src="@drawable/sym_keyboard_shift_locked_lxx_dark" android:tint="@color/icon_tint_system_accent_lxx_light" />

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -23,19 +23,15 @@
     <color name="highlight_color_lxx_light">@android:color/system_accent1_500</color>
     <color name="gesture_trail_color_lxx_light">@android:color/system_accent1_200</color>
     <color name="sliding_key_input_preview_color_lxx_light">@android:color/system_accent1_900</color>
-    <color name="action_key_background_lxx_light">@android:color/system_accent1_500</color>
+    <color name="action_key_background_lxx_light">@color/highlight_color_lxx_light</color>
     <color name="action_key_background_pressed_lxx_light">@android:color/system_accent1_200</color>
+    <color name="icon_tint_system_accent_lxx_light">@color/highlight_color_lxx_light</color>
 
     <!-- System theming colors for LXX_Dark theme, overriding some colors in main colors.xml -->
     <color name="highlight_color_lxx_dark">@android:color/system_accent1_500</color>
     <color name="gesture_trail_color_lxx_dark">@android:color/system_accent1_200</color>
     <color name="sliding_key_input_preview_color_lxx_dark">@android:color/system_accent1_900</color>
-    <color name="action_key_background_lxx_dark">@android:color/system_accent1_500</color>
+    <color name="action_key_background_lxx_dark">@color/highlight_color_lxx_dark</color>
     <color name="action_key_background_pressed_lxx_dark">@android:color/system_accent1_200</color>
-
-    <!-- System theming color for icons in Material themes. The colors are different because the
-    icons have some transparency (so the background color affects shading) -->
-    <!-- Both themes apply this color as a tint to the normal_lxx_dark icons -->
-    <color name="icon_tint_system_accent_lxx_dark">@android:color/system_accent1_300</color>
-    <color name="icon_tint_system_accent_lxx_light">@android:color/system_accent1_600</color>
+    <color name="icon_tint_system_accent_lxx_dark">@color/highlight_color_lxx_dark</color>
 </resources>

--- a/app/src/main/res/values-v31/keyboard-icons-lxx-dark.xml
+++ b/app/src/main/res/values-v31/keyboard-icons-lxx-dark.xml
@@ -19,29 +19,8 @@
 -->
 
 <resources>
-    <style name="KeyboardIcons.LXX_Dark">
-        <!-- Keyboard icons -->
-        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_dark</item>
+    <style name="KeyboardIcons.LXX_Dark" parent="KeyboardIcons.LXX_Dark.Parent">
+        <!-- Use system accent color for shifted shift key -->
         <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_dark_system_accent</item>
-        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_dark</item>
-        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_dark</item>
-        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_dark</item>
-        <item name="iconSpaceKey">@null</item>
-        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_dark</item>
-        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_dark</item>
-        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_dark</item>
-        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_dark</item>
-        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_dark</item>
-        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_dark</item>
-        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_dark</item>
-        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_dark</item>
-        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_dark</item>
-        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_dark</item>
-        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_dark</item>
-        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_dark</item>
-        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_dark</item>
-        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_dark</item>
-        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
-        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/keyboard-icons-lxx-light.xml
+++ b/app/src/main/res/values-v31/keyboard-icons-lxx-light.xml
@@ -19,29 +19,8 @@
 -->
 
 <resources>
-    <style name="KeyboardIcons.LXX_Light">
-        <!-- Keyboard icons -->
-        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_light</item>
+    <style name="KeyboardIcons.LXX_Light" parent="KeyboardIcons.LXX_Light.Parent">
+        <!-- Use system accent color for shifted shift key -->
         <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_light_system_accent</item>
-        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_light</item>
-        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_light</item>
-        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_light</item>
-        <item name="iconSpaceKey">@null</item>
-        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_light</item>
-        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_light</item>
-        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_light</item>
-        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_light</item>
-        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_light</item>
-        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_light</item>
-        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_light</item>
-        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_light</item>
-        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_light</item>
-        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_light</item>
-        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_light</item>
-        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_light</item>
-        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_light</item>
-        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_light</item>
-        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
-        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_light</item>
     </style>
 </resources>

--- a/app/src/main/res/values/keyboard-icons-lxx-dark-parent.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-dark-parent.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources>
+    <style name="KeyboardIcons.LXX_Dark.Parent">
+        <!-- Keyboard icons -->
+        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_dark</item>
+        <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_dark</item>
+        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_dark</item>
+        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_dark</item>
+        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_dark</item>
+        <item name="iconSpaceKey">@null</item>
+        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_dark</item>
+        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_dark</item>
+        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_dark</item>
+        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_dark</item>
+        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_dark</item>
+        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_dark</item>
+        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_dark</item>
+        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_dark</item>
+        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_dark</item>
+        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_dark</item>
+        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_dark</item>
+        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_dark</item>
+        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_dark</item>
+        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_dark</item>
+        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
+        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/keyboard-icons-lxx-dark.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-dark.xml
@@ -19,29 +19,5 @@
 -->
 
 <resources>
-    <style name="KeyboardIcons.LXX_Dark">
-        <!-- Keyboard icons -->
-        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_dark</item>
-        <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_dark</item>
-        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_dark</item>
-        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_dark</item>
-        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_dark</item>
-        <item name="iconSpaceKey">@null</item>
-        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_dark</item>
-        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_dark</item>
-        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_dark</item>
-        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_dark</item>
-        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_dark</item>
-        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_dark</item>
-        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_dark</item>
-        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_dark</item>
-        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_dark</item>
-        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_dark</item>
-        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_dark</item>
-        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_dark</item>
-        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_dark</item>
-        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_dark</item>
-        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
-        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
-    </style>
+    <style name="KeyboardIcons.LXX_Dark" parent="KeyboardIcons.LXX_Dark.Parent" />
 </resources>

--- a/app/src/main/res/values/keyboard-icons-lxx-light-parent.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-light-parent.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources>
+    <style name="KeyboardIcons.LXX_Light.Parent">
+        <!-- Keyboard icons -->
+        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_light</item>
+        <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_light</item>
+        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_light</item>
+        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_light</item>
+        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_light</item>
+        <item name="iconSpaceKey">@null</item>
+        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_light</item>
+        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_light</item>
+        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_light</item>
+        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_light</item>
+        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_light</item>
+        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_light</item>
+        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_light</item>
+        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_light</item>
+        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_light</item>
+        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_light</item>
+        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_light</item>
+        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_light</item>
+        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_light</item>
+        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_light</item>
+        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
+        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_light</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/keyboard-icons-lxx-light.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-light.xml
@@ -19,29 +19,5 @@
 -->
 
 <resources>
-    <style name="KeyboardIcons.LXX_Light">
-        <!-- Keyboard icons -->
-        <item name="iconShiftKey">@drawable/sym_keyboard_shift_lxx_light</item>
-        <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_lxx_light</item>
-        <item name="iconDeleteKey">@drawable/sym_keyboard_delete_lxx_light</item>
-        <item name="iconTabKey">@drawable/sym_keyboard_tab_lxx_light</item>
-        <item name="iconSettingsKey">@drawable/sym_keyboard_settings_lxx_light</item>
-        <item name="iconSpaceKey">@null</item>
-        <item name="iconEnterKey">@drawable/sym_keyboard_return_lxx_light</item>
-        <item name="iconGoKey">@drawable/sym_keyboard_go_lxx_light</item>
-        <item name="iconSearchKey">@drawable/sym_keyboard_search_lxx_light</item>
-        <item name="iconSendKey">@drawable/sym_keyboard_send_lxx_light</item>
-        <item name="iconNextKey">@drawable/sym_keyboard_next_lxx_light</item>
-        <item name="iconDoneKey">@drawable/sym_keyboard_done_lxx_light</item>
-        <item name="iconPreviousKey">@drawable/sym_keyboard_previous_lxx_light</item>
-        <item name="iconShortcutKey">@drawable/sym_keyboard_voice_lxx_light</item>
-        <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_lxx_light</item>
-        <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx_light</item>
-        <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx_light</item>
-        <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx_light</item>
-        <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx_light</item>
-        <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx_light</item>
-        <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx_dark</item>
-        <item name="iconEmojiNormalKey">@drawable/sym_keyboard_smiley_lxx_light</item>
-    </style>
+    <style name="KeyboardIcons.LXX_Light" parent="KeyboardIcons.LXX_Light.Parent" />
 </resources>


### PR DESCRIPTION
The tint was being applied to the "normal" icon, which has an alpha less than 1, causing the tint to appear incorrect. Changed to the "activated" icon, which has an alpha of 1 for most of the image, so tints are now consistent.