### PR TITLE
Update spellchecker locale while typing and get locale from keyboard if available

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
@@ -24,6 +24,8 @@ import android.service.textservice.SpellCheckerService.Session;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.LruCache;
+import android.view.inputmethod.InputMethodManager;
+import android.view.inputmethod.InputMethodSubtype;
 import android.view.textservice.SuggestionsInfo;
 import android.view.textservice.TextInfo;
 
@@ -110,12 +112,47 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
         cres.registerContentObserver(Words.CONTENT_URI, true, mObserver);
     }
 
+    private void updateLocale() {
+        final String localeString = getLocale();
+
+        if (mLocale == null || !mLocale.toString().equals(localeString)) {
+            final String oldLocal = mLocale == null ? "null" : mLocale.toString();
+            Log.d(TAG, "Updating locale from " + oldLocal + " to " + localeString);
+
+            mLocale = (null == localeString) ? null
+                    : LocaleUtils.constructLocaleFromString(localeString);
+            mScript = ScriptUtils.getScriptFromSpellCheckerLocale(mLocale);
+        }
+    }
+
     @Override
     public void onCreate() {
-        final String localeString = getLocale();
-        mLocale = (null == localeString) ? null
-                : LocaleUtils.constructLocaleFromString(localeString);
-        mScript = ScriptUtils.getScriptFromSpellCheckerLocale(mLocale);
+        updateLocale();
+    }
+
+    @Override
+    public String getLocale() {
+        // This function was taken from https://github.com/LineageOS/android_frameworks_base/blob/1235c24a0f092d0e41fd8e86f332f8dc03896a7b/services/core/java/com/android/server/TextServicesManagerService.java#L544 and slightly adopted.
+
+        final InputMethodManager imm;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            imm = mService.getApplicationContext()
+                    .getSystemService(InputMethodManager.class);
+            if (imm != null) {
+                final InputMethodSubtype currentInputMethodSubtype =
+                        imm.getCurrentInputMethodSubtype();
+                if (currentInputMethodSubtype != null) {
+                    final String localeString = currentInputMethodSubtype.getLocale();
+                    if (!TextUtils.isEmpty(localeString)) {
+                        // Use keyboard locale if available in the spell checker
+                        return localeString;
+                    }
+                }
+            }
+        }
+
+        // Fallback to system locale
+        return super.getLocale();
     }
 
     @Override
@@ -189,6 +226,7 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
      *  version of it "text" and the capitalized version of it "Text".
      */
     private boolean isInDictForAnyCapitalization(final String text, final int capitalizeType) {
+        updateLocale();
         // If the word is in there as is, then it's in the dictionary. If not, we'll test lower
         // case versions, but only if the word is not already all-lower case or mixed case.
         if (mService.isValidWord(mLocale, text)) return true;
@@ -222,6 +260,7 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
     protected SuggestionsInfo onGetSuggestionsInternal(
             final TextInfo textInfo, final NgramContext ngramContext, final int suggestionsLimit) {
         try {
+            updateLocale();
             final String text = textInfo.getText().
                     replaceAll(AndroidSpellCheckerService.APOSTROPHE,
                             AndroidSpellCheckerService.SINGLE_QUOTE).

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
@@ -226,7 +226,6 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
      *  version of it "text" and the capitalized version of it "Text".
      */
     private boolean isInDictForAnyCapitalization(final String text, final int capitalizeType) {
-        updateLocale();
         // If the word is in there as is, then it's in the dictionary. If not, we'll test lower
         // case versions, but only if the word is not already all-lower case or mixed case.
         if (mService.isValidWord(mLocale, text)) return true;


### PR DESCRIPTION
This PR contains two changes

1. The spellchecker updates its locale while typing. This is currently implemented rather inefficiently since the code checks if the locale changed each time it performs some spellchecking. I unfortunately don't know if and how its possible to do this in a more efficient manner. 
2. The code now tries to get the locale from the keyboard if its available. This would fix #258. Thanks a lot @ClearlyClaire for the investigation into why this wasn't working.

I do not have any experience developing android applications so feel free to point out anything wrong/non-optimal :)