### PR TITLE
Fix #520 Red underline upon sentence completion

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
@@ -296,16 +296,19 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
             // Handle special patterns like email, URI, telephone number.
             final int checkability = getCheckabilityInScript(text, mScript);
             if (CHECKABILITY_CHECKABLE != checkability) {
+                // CHECKABILITY_CONTAINS_PERIOD Typo should not be reported when text is a valid word followed by a single period (end of sentence).
+                boolean periodOnlyAtLastIndex = text.indexOf(Constants.CODE_PERIOD) == (text.length() - 1);
                 if (CHECKABILITY_CONTAINS_PERIOD == checkability) {
                     final String[] splitText = text.split(Constants.REGEXP_PERIOD);
                     boolean allWordsAreValid = true;
+                    // Validate all words on both sides of periods, skip empty tokens due to periods at first/last index
                     for (final String word : splitText) {
-                        if (!mService.isValidWord(mLocale, word)) {
+                        if (!word.isEmpty() && !mService.isValidWord(mLocale, word)) {
                             allWordsAreValid = false;
                             break;
                         }
                     }
-                    if (allWordsAreValid) {
+                    if (allWordsAreValid && !periodOnlyAtLastIndex) {
                         return new SuggestionsInfo(SuggestionsInfo.RESULT_ATTR_LOOKS_LIKE_TYPO
                                 | SuggestionsInfo.RESULT_ATTR_HAS_RECOMMENDED_SUGGESTIONS,
                                 new String[] {
@@ -314,8 +317,7 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
                 }
                 return mService.isValidWord(mLocale, text) ?
                         AndroidSpellCheckerService.getInDictEmptySuggestions() :
-                        AndroidSpellCheckerService.getNotInDictEmptySuggestions(
-                                CHECKABILITY_CONTAINS_PERIOD == checkability /* reportAsTypo */);
+                        AndroidSpellCheckerService.getNotInDictEmptySuggestions(!periodOnlyAtLastIndex);
             }
 
             // Handle normal words.

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/spellcheck/AndroidWordLevelSpellCheckerSession.java
@@ -303,7 +303,7 @@ public abstract class AndroidWordLevelSpellCheckerSession extends Session {
                     boolean allWordsAreValid = true;
                     // Validate all words on both sides of periods, skip empty tokens due to periods at first/last index
                     for (final String word : splitText) {
-                        if (!word.isEmpty() && !mService.isValidWord(mLocale, word)) {
+                        if (!word.isEmpty() && !mService.isValidWord(mLocale, word) && !mService.isValidWord(mLocale, word.toLowerCase(mLocale))) {
                             allWordsAreValid = false;
                             break;
                         }


### PR DESCRIPTION
Addresses #520 

This PR addresses spellcheck highlighting at the ends of sentences when a valid word is followed by a period, and alters the existing special handling around words that contain periods.


~


**Issue:**

Valid words were being erroneously flagged by the spellchecker when followed by a period. 

![OpenBoard1_4_5](https://user-images.githubusercontent.com/6745966/185520784-7e0692cd-55b2-4fa6-b3d3-ed84a8807cce.png)
_Reproduction on OpenBoard 1.4.5_


~


**Resolution:**

Valid words followed by periods are no longer flagged. Invalid words followed by periods are still flagged, and the intent behind the existing logic to flag and suggest valid words on either side of a period within a token should not be impacted by this change (see below).

![AfterChanges](https://user-images.githubusercontent.com/6745966/185520785-d0b56dc6-8d71-46c4-9426-c0b6851c2749.png)
_Testing on Pixel 5 Android 13_

![AfterChangesShowSuggestions](https://user-images.githubusercontent.com/6745966/185520786-fc0c6423-06e2-4bd7-9da2-c0d38d275973.png)
_Valid words on either side of an interceding period are suggested with a space as separator_


~


**Additional Considerations for CHECKABILITY_CONTAINS_PERIOD:**

- Empty words are considered invalid. In CHECKABILITY_CONTAINS_PERIOD, when a period was the first or last index of text, splitting that text on periods caused suggestions to consider potentially valid words to be invalid. For example, "this.example." should suggest "this example" or "this example.", but no suggestions were being given due to the trailing empty string resulting from the split operation being considered invalid. This PR modifies this behavior such that empty split tokens will not be considered toward word validity when generating suggestions for text containing periods.

- Single word sentences (like "Groovy.") were being flagged as invalid since the word only exists in the main dictionary as lower case, but the validity check within CHECKABILITY_CONTAINS_PERIOD sent text over as is. This PR adds, specific to the period checkability logic, a fallback validity check for words set to lower case.
