### PR TITLE
Enable suggestions after ¿ and ¡ characters in Spanish

### DIFF
--- a/app/src/main/res/values-es/donottranslate-config-spacing-and-punctuations.xml
+++ b/app/src/main/res/values-es/donottranslate-config-spacing-and-punctuations.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="symbols_word_separators">"&#x0009;&#x0020;&#x000A;&#x00A0;"()[]{}*&amp;&lt;&gt;+=|.,;:!?¡¿/_\"</string>
+</resources>


### PR DESCRIPTION
fixes #667

This adds `¡` and `¿` characters to the Spanish `symbols_word_separators`, enabling suggestions following those characters.