### PR TITLE
[DRAFT] Make Dvorak number row aware, and add press and hold symbols

### DIFF
--- a/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
+++ b/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
@@ -18,42 +18,77 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&quot;"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-            <Key
-                latin:keySpec="&lt;"
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2" />
-            <Key
-                latin:keySpec="&gt;"
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3" />
+        <case latin:numberRowEnabled="true">
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="\'" />
+                    <Key
+                        latin:additionalMoreKeys="\\"
+                        latin:keyHintLabel="\\"
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="|"
+                        latin:keyHintLabel="|"
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                    <Key
+                        latin:additionalMoreKeys="\\"
+                        latin:keyHintLabel="\\"
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="|"
+                        latin:keyHintLabel="|"
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </case>
         <default>
-            <Key
-                latin:keySpec="\'"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!,&quot;" />
-            <Key
-                latin:keySpec=","
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2"
-                latin:moreKeys="\?,&lt;" />
-            <Key
-                latin:keySpec="."
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3"
-                latin:moreKeys="&gt;" />
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="&quot;" />
+                    <Key
+                        latin:additionalMoreKeys="2"
+                        latin:keyHintLabel="2"
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="3"
+                        latin:keyHintLabel="3"
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                    <Key
+                        latin:additionalMoreKeys="2"
+                        latin:keyHintLabel="2"
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="3"
+                        latin:keyHintLabel="3"
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml-sw600dp/rowkeys_dvorak3.xml
+++ b/app/src/main/res/xml-sw600dp/rowkeys_dvorak3.xml
@@ -25,21 +25,36 @@
         latin:keySpec="q" />
     <Key
         latin:keySpec="j"
+        latin:keyHintLabel="*"
+        latin:additionalMoreKeys="*"
         latin:moreKeys="!text/morekeys_j" />
     <Key
         latin:keySpec="k"
+        latin:keyHintLabel="&quot;"
+        latin:additionalMoreKeys="&quot;"
         latin:moreKeys="!text/morekeys_k" />
     <Key
-        latin:keySpec="x" />
+        latin:keySpec="x"
+        latin:keyHintLabel="'"
+        latin:additionalMoreKeys="'"
+        />
     <Key
-        latin:keySpec="b" />
+        latin:keySpec="b"
+        latin:keyHintLabel=":"
+        latin:additionalMoreKeys=":" />
     <Key
-        latin:keySpec="m" />
+        latin:keySpec="m"
+        latin:keyHintLabel=";"
+        latin:additionalMoreKeys=";" />
     <Key
         latin:keySpec="w"
+        latin:keyHintLabel="!"
+        latin:additionalMoreKeys="!"
         latin:moreKeys="!text/morekeys_w" />
     <Key
         latin:keySpec="v"
+        latin:keyHintLabel="\?"
+        latin:additionalMoreKeys="\?"
         latin:moreKeys="!text/morekeys_v" />
     <Key
         latin:keySpec="z"

--- a/app/src/main/res/xml/keys_dvorak_123.xml
+++ b/app/src/main/res/xml/keys_dvorak_123.xml
@@ -18,66 +18,113 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&quot;"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-        </case>
-        <case
-            latin:mode="url"
-        >
-            <Key
-                latin:keySpec="/"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-        </case>
-        <case
-            latin:mode="email"
-        >
-            <Key
-                latin:keySpec="\@"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
+        <case latin:numberRowEnabled="true">
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="&quot;" />
+                </case>
+                <case latin:mode="url">
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="/" />
+                </case>
+                <case latin:mode="email">
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="\@" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="%"
+                        latin:keyHintLabel="%"
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                </default>
+            </switch>
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="\\"
+                        latin:keyHintLabel="\\"
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="|"
+                        latin:keyHintLabel="|"
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="\\"
+                        latin:keyHintLabel="\\"
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="|"
+                        latin:keyHintLabel="|"
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </case>
         <default>
-            <Key
-                latin:keySpec="\'"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!,&quot;" />
-        </default>
-    </switch>
-    <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&lt;"
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2" />
-            <Key
-                latin:keySpec="&gt;"
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3" />
-        </case>
-        <default>
-            <Key
-                latin:keySpec=","
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2"
-                latin:moreKeys="\?,&lt;" />
-            <Key
-                latin:keySpec="."
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3"
-                latin:moreKeys="&gt;" />
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="&quot;" />
+                </case>
+                <case latin:mode="url">
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="/" />
+                </case>
+                <case latin:mode="email">
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="\@" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="1"
+                        latin:keyHintLabel="1"
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                </default>
+            </switch>
+            <switch>
+                <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+                    <Key
+                        latin:additionalMoreKeys="2"
+                        latin:keyHintLabel="2"
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="3"
+                        latin:keyHintLabel="3"
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:additionalMoreKeys="2"
+                        latin:keyHintLabel="2"
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:additionalMoreKeys="3"
+                        latin:keyHintLabel="3"
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak1.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak1.xml
@@ -48,7 +48,7 @@
                 latin:keySpec="c"
                 latin:moreKeys="!text/morekeys_c" />
             <Key
-                latin:additionalMoreKeys="}"
+                latin:additionalMoreKeys="{"
                 latin:keyHintLabel="{"
                 latin:keySpec="r"
                 latin:moreKeys="!text/morekeys_r" />

--- a/app/src/main/res/xml/rowkeys_dvorak1.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak1.xml
@@ -18,42 +18,80 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <include
-        latin:keyboardLayout="@xml/keys_dvorak_123" />
-    <Key
-        latin:keySpec="p"
-        latin:keyHintLabel="4"
-        latin:additionalMoreKeys="4" />
-    <Key
-        latin:keySpec="y"
-        latin:keyHintLabel="5"
-        latin:additionalMoreKeys="5"
-        latin:moreKeys="!text/morekeys_y" />
-    <Key
-        latin:keySpec="f"
-        latin:keyHintLabel="6"
-        latin:additionalMoreKeys="6" />
-    <Key
-        latin:keySpec="g"
-        latin:keyHintLabel="7"
-        latin:additionalMoreKeys="7"
-        latin:moreKeys="!text/morekeys_g" />
-    <Key
-        latin:keySpec="c"
-        latin:keyHintLabel="8"
-        latin:additionalMoreKeys="8"
-        latin:moreKeys="!text/morekeys_c" />
-    <Key
-        latin:keySpec="r"
-        latin:keyHintLabel="9"
-        latin:additionalMoreKeys="9"
-        latin:moreKeys="!text/morekeys_r" />
-    <Key
-        latin:keySpec="l"
-        latin:keyHintLabel="0"
-        latin:additionalMoreKeys="0"
-        latin:moreKeys="!text/morekeys_l" />
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <!-- keys_dvorak_123 is number row aware -->
+    <include latin:keyboardLayout="@xml/keys_dvorak_123" />
+    <switch>
+        <case latin:numberRowEnabled="true">
+
+            <Key
+                latin:additionalMoreKeys="="
+                latin:keyHintLabel="="
+                latin:keySpec="p" />
+            <Key
+                latin:additionalMoreKeys="["
+                latin:keyHintLabel="["
+                latin:keySpec="y"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:additionalMoreKeys="]"
+                latin:keyHintLabel="]"
+                latin:keySpec="f" />
+            <Key
+                latin:additionalMoreKeys="&lt;"
+                latin:keyHintLabel="&lt;"
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:additionalMoreKeys="&gt;"
+                latin:keyHintLabel="&gt;"
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:additionalMoreKeys="}"
+                latin:keyHintLabel="{"
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:additionalMoreKeys="}"
+                latin:keyHintLabel="}"
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+        </case>
+        <default>
+            <Key
+                latin:additionalMoreKeys="4"
+                latin:keyHintLabel="4"
+                latin:keySpec="p" />
+            <Key
+                latin:additionalMoreKeys="5"
+                latin:keyHintLabel="5"
+                latin:keySpec="y"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:additionalMoreKeys="6"
+                latin:keyHintLabel="6"
+                latin:keySpec="f" />
+            <Key
+                latin:additionalMoreKeys="7"
+                latin:keyHintLabel="7"
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:additionalMoreKeys="8"
+                latin:keyHintLabel="8"
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:additionalMoreKeys="9"
+                latin:keyHintLabel="9"
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:additionalMoreKeys="0"
+                latin:keyHintLabel="0"
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak2.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak2.xml
@@ -23,32 +23,52 @@
 >
     <Key
         latin:keySpec="a"
+        latin:keyHintLabel="\@"
+        latin:additionalMoreKeys="\\@"
         latin:moreKeys="!text/morekeys_a" />
     <Key
         latin:keySpec="o"
+        latin:keyHintLabel="#"
+        latin:additionalMoreKeys="#"
         latin:moreKeys="!text/morekeys_o" />
     <Key
         latin:keySpec="e"
+        latin:keyHintLabel="€"
+        latin:additionalMoreKeys="€"
         latin:moreKeys="!text/morekeys_e" />
     <Key
         latin:keySpec="u"
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_"
         latin:moreKeys="!text/morekeys_u" />
     <Key
         latin:keySpec="i"
+        latin:keyHintLabel="&amp;"
+        latin:additionalMoreKeys="&amp;"
         latin:moreKeys="!text/morekeys_i" />
     <Key
         latin:keySpec="d"
+        latin:keyHintLabel="-"
+        latin:additionalMoreKeys="-"
         latin:moreKeys="!text/morekeys_d" />
     <Key
         latin:keySpec="h"
+        latin:keyHintLabel="+"
+        latin:additionalMoreKeys="+"
         latin:moreKeys="!text/morekeys_h" />
     <Key
         latin:keySpec="t"
+        latin:keyHintLabel="("
+        latin:additionalMoreKeys="("
         latin:moreKeys="!text/morekeys_t" />
     <Key
         latin:keySpec="n"
+        latin:keyHintLabel=")"
+        latin:additionalMoreKeys=")"
         latin:moreKeys="!text/morekeys_n" />
     <Key
         latin:keySpec="s"
+        latin:keyHintLabel="/"
+        latin:additionalMoreKeys="/"
         latin:moreKeys="!text/morekeys_s" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak3.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak3.xml
@@ -23,20 +23,35 @@
 >
     <Key
         latin:keySpec="j"
+        latin:keyHintLabel="*"
+        latin:additionalMoreKeys="*"
         latin:moreKeys="!text/morekeys_j" />
     <Key
         latin:keySpec="k"
+        latin:keyHintLabel="&quot;"
+        latin:additionalMoreKeys="&quot;"
         latin:moreKeys="!text/morekeys_k" />
     <Key
-        latin:keySpec="x" />
+        latin:keySpec="x"
+        latin:keyHintLabel="'"
+        latin:additionalMoreKeys="'"
+        />
     <Key
-        latin:keySpec="b" />
+        latin:keySpec="b"
+        latin:keyHintLabel=":"
+        latin:additionalMoreKeys=":" />
     <Key
-        latin:keySpec="m" />
+        latin:keySpec="m"
+        latin:keyHintLabel=";"
+        latin:additionalMoreKeys=";" />
     <Key
         latin:keySpec="w"
+        latin:keyHintLabel="!"
+        latin:additionalMoreKeys="!"
         latin:moreKeys="!text/morekeys_w" />
     <Key
         latin:keySpec="v"
+        latin:keyHintLabel="\?"
+        latin:additionalMoreKeys="\?"
         latin:moreKeys="!text/morekeys_v" />
 </merge>


### PR DESCRIPTION
# Dvorak Improvements

This is a draft for dealing with issue #712

I tried it out with English (US + UK), German and Spanish (does not solve #394 though, because that requires additional keys).

This works more or less, but as it stands, there are two problems/discussion points with this draft. Since I don't know how to approach that, I'm opening this, in case someone has a useful pointer for me, and to discuss, whether these problems are dealbreakers.

## Hard Coded Currency Symbol

The currency symbol on the 'e' is set to the '€' sign, because that's what I need for my German layout, but it should be a '$' on the US keyboard (and probably a '£' sign on the UK keyboard). The symbol layer is unaffected by this. QWERTY variant keyboards (cf. US/UK) also don't account for that on the first layer as far as I can see, so maybe just putting a '$' as default and calling it a day would be good enough, but that's not for me to decide.
In case it is not, I don't think it would be feasible to define multiple Dvorak variants because of the additional maintenance burden, but I don't know if there's a way to use a placeholder value instead of the symbol.

There is `currencyKeyStyle`, but I think it can't be used as a value for `keyHintLabel` or `additionalMoreKeys`.

Another thing I considered was adding a separate file for the 'e' key and including that.
In there, one could switch on the selected language, but I don't know whether that is even possible, and if so it still seems very unclean.

## Design

The switching 'logic' is based off of the way the QWERTY and QWERTZ keyboards are doing it, but because Dvorak is a little special with the first three symbol keys on the upper row (defined in `res/xml(sw600dp)?/keys_dvorak_123.xml`) those get a little unwieldy with nested switches.

A cleaner way might be to just add new files (e.g. `keys_dvorak_123_numrow.xml` and `keys_dvorak_123_no_numrow.xml`) and including those in `keys_dvorak_123.xml` based on a switch.

If requested, I can make this change.

---

As an addendum:
The QWERTZ keyboard is splitting left and right row halves, I don't know whether this is for limiting the unwieldiness of the files, or some split functionality, that I haven't discovered yet, but if that is a more suitable way to organize these files, I can certainly do that as well.